### PR TITLE
Accordion: Fix "t.map is not a function" error

### DIFF
--- a/src/lib/components/Accordion.react.js
+++ b/src/lib/components/Accordion.react.js
@@ -15,7 +15,7 @@ const Accordion = (props) => {
 
     return (
         <MantineAccordion {...omit(["setProps"], props)} onChange={onChange}>
-            {children.map((child, index) => {
+            {React.Children.map(children, (child, index) => {
                 const childProps = child.props._dashprivate_layout.props;
                 return (
                     <MantineAccordion.Item

--- a/src/lib/components/Grid.react.js
+++ b/src/lib/components/Grid.react.js
@@ -11,7 +11,7 @@ const Grid = (props) => {
 
     return (
         <MantineGrid {...omit(["setProps", "children"], props)}>
-            {children.map((child, index) => {
+            {React.Children.map(children, (child, index) => {
                 const childProps = child.props._dashprivate_layout.props;
                 return (
                     <MantineCol {...omit(["children"], childProps)} key={index}>

--- a/src/lib/components/Group.react.js
+++ b/src/lib/components/Group.react.js
@@ -15,7 +15,7 @@ const Group = (props) => {
 
     return (
         <MantineGroup {...omit(["children", "setProps"], props)}>
-            {children.map((child, index) => {
+            {React.Children.map(children, (child, index) => {
                 return <div key={index}>{child}</div>;
             })}
         </MantineGroup>

--- a/src/lib/components/Tabs.react.js
+++ b/src/lib/components/Tabs.react.js
@@ -15,7 +15,7 @@ const Tabs = (props) => {
 
     return (
         <MantineTabs {...omit(["setProps"], props)} onTabChange={onTabChange}>
-            {children.map((child, index) => {
+            {React.Children.map(children, (child, index) => {
                 const childProps = child.props._dashprivate_layout.props;
                 return (
                     <Tab {...omit(["children"], childProps)} key={index}>


### PR DESCRIPTION
In React, it is not safe to iterate the children attribute using map. Rather, the `React.Children.map` construct should be used,

https://stackoverflow.com/questions/34030328/how-to-iterate-through-a-components-children-in-typescript-react

Specifically, I get an error with the current code ("t.map is not a function") is a pass list with only one `AccordionItem` to the `Accordion` component. The PR fixes that error.