### PR TITLE
Add ScrollArea component

### DIFF
--- a/src/lib/components/ScrollArea.react.js
+++ b/src/lib/components/ScrollArea.react.js
@@ -9,7 +9,7 @@ import { pick } from "ramda";
 const ScrollArea = (props) => {
     return (
         <MantineScrollArea
-            {...pick(["dir", "offsetScrollbars", "scrollHideDelay", "scrollbarSize", "type"], props)}
+            {...omit(["setProps", "children"], props)}
         >
             {props.children}
         </MantineScrollArea>
@@ -73,9 +73,14 @@ ScrollArea.propTypes = {
     style: PropTypes.object,
 
     /**
-     * Table children
+     * ScrollArea children
      */
-    children: PropTypes.node
+    children: PropTypes.node,
+
+    /**
+     * Tells dash if any prop has changed its value
+     */
+    setProps: PropTypes.func,
 };
 
 export default ScrollArea;

--- a/src/lib/components/ScrollArea.react.js
+++ b/src/lib/components/ScrollArea.react.js
@@ -1,0 +1,81 @@
+import React from "react";
+import { ScrollArea as MantineScrollArea } from "@mantine/core";
+import PropTypes from "prop-types";
+import { pick } from "ramda";
+
+/**
+ * A port of the ScrollArea component. For more information, see: https://mantine.dev/core/table/
+ */
+const ScrollArea = (props) => {
+    return (
+        <MantineScrollArea
+            {...pick(["dir", "offsetScrollbars", "scrollHideDelay", "scrollbarSize", "type"], props)}
+        >
+            {props.children}
+        </MantineScrollArea>
+    );
+};
+
+ScrollArea.displayName = "ScrollArea";
+
+ScrollArea.defaultProps = {
+    dir: "ltr",
+    offsetScrollbars: false,
+    scrollHideDelay: 1000,
+    scrollbarSize: 12,
+    type: "hover"
+};
+
+ScrollArea.propTypes = {
+    /**
+     * Reading direction of the scroll area
+     */
+     dir: PropTypes.oneOf(["ltr", "rtl"]),
+
+    /**
+     * Should scrollbars be offset with padding
+     */
+     offsetScrollbars: PropTypes.bool,
+
+    /**
+     * Scroll hide delay in ms, for scroll and hover types only
+     */
+     scrollHideDelay: PropTypes.number,
+
+    /**
+     * Scrollbar size in px
+     */
+     scrollbarSize: PropTypes.number,
+
+    /**
+     * Scrollbars type
+     */
+     type: PropTypes.oneOf(["auto", "scroll", "always", "hover"]),
+
+    // /**
+    //  * If true row will have hover color
+    //  */
+    //  viewportRef: ForwardedRef<HTMLDivElement>,
+
+    /**
+     * Often used with CSS to style elements with common properties
+     */
+    className: PropTypes.string,
+
+    /**
+     * The ID of this component, used to identify dash components in callbacks
+     */
+    id: PropTypes.string,
+
+    /**
+     * Inline style override
+     */
+    style: PropTypes.object,
+
+    /**
+     * Table children
+     */
+    children: PropTypes.node
+};
+
+export default ScrollArea;

--- a/src/lib/components/ScrollArea.react.js
+++ b/src/lib/components/ScrollArea.react.js
@@ -53,7 +53,7 @@ ScrollArea.propTypes = {
      type: PropTypes.oneOf(["auto", "scroll", "always", "hover"]),
 
     // /**
-    //  * If true row will have hover color
+    //  * Get viewport ref
     //  */
     //  viewportRef: ForwardedRef<HTMLDivElement>,
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -42,7 +42,9 @@ import Breadcrumbs from "./components/Breadcrumbs.react";
 import Progress from "./components/Progress.react";
 import NotificationsProvider from "./components/NotificationsProvider.react";
 import NotificationHandler from "./components/NotificationHandler.react";
+import ScrollArea from "./components/ScrollArea.react";
 // import RangeSlider from './components/RangeSlider.react';
+
 
 export {
     Button,
@@ -89,5 +91,6 @@ export {
     Progress,
     NotificationsProvider,
     NotificationHandler,
+    ScrollArea,
     // RangeSlider,
 };


### PR DESCRIPTION
The PRs adds the `ScrollArea` component,

https://mantine.dev/core/scroll-area/

Here is a small example, which yields vertical and horizontal scroll bars,

```
from dash import Dash, html
import dash_mantine_components as dmc

content = """Charizard is a draconic, bipedal Pokémon. It is primarily orange with a cream underside from the chest 
to the tip of its tail. It has a long neck, small blue eyes, slightly raised nostrils, and two horn-like structures 
protruding from the back of its rectangular head. There are two fangs visible in the upper jaw when its mouth is 
closed. Two large wings with blue-green undersides sprout from its back, and a horn-like appendage juts out from the 
top of the third joint of each wing. A single wing-finger is visible through the center of each wing membrane. 
Charizard's arms are short and skinny compared to its robust belly, and each limb has three white claws. It has 
stocky legs with cream-colored soles on each of its plantigrade feet. The tip of its long, tapering tail burns with a 
sizable flame. """

# Small example app.
app = Dash()
app.layout = html.Div(
    dmc.ScrollArea(
        html.Div(content, style=dict(width="200px", height="200px")),
    ), style=dict(height="100px", width="100px"),
)

if __name__ == '__main__':
    app.run_server()
```