### PR TITLE
Change table to use html representation

### DIFF
--- a/src/lib/components/Table.react.js
+++ b/src/lib/components/Table.react.js
@@ -7,7 +7,7 @@ import { pick } from "ramda";
  * A simple table component. For more information, see: https://mantine.dev/core/table/
  */
 const Table = (props) => {
-    const { class_name, caption, children } = props;
+    const { class_name, children } = props;
     return (
         <MantineTable
             {...pick(

--- a/src/lib/components/Table.react.js
+++ b/src/lib/components/Table.react.js
@@ -7,24 +7,7 @@ import { pick } from "ramda";
  * A simple table component. For more information, see: https://mantine.dev/core/table/
  */
 const Table = (props) => {
-    const { rows, columns, class_name } = props;
-
-    const ths = (
-        <tr>
-            {columns.map((col, index) => {
-                return <th key={index}>{col}</th>;
-            })}
-        </tr>
-    );
-
-    const trs = rows.map((row, idx1) => (
-        <tr key={idx1}>
-            {row.map((ele, idx2) => {
-                return <td key={idx2 + idx1}>{ele}</td>;
-            })}
-        </tr>
-    ));
-
+    const { class_name, caption, children } = props;
     return (
         <MantineTable
             {...pick(
@@ -33,15 +16,12 @@ const Table = (props) => {
                     "highlightOnHover",
                     "style",
                     "captionSide",
-                    "class_name",
                 ],
                 props
             )}
             className={class_name}
         >
-            <caption>{props.caption}</caption>
-            <thead>{ths}</thead>
-            <tbody>{trs}</tbody>
+            {children}
         </MantineTable>
     );
 };
@@ -50,16 +30,9 @@ Table.displayName = "Table";
 
 Table.defaultProps = {
     captionSide: "bottom",
-    rows: [],
-    columns: [],
 };
 
 Table.propTypes = {
-    /**
-     * Table description
-     */
-    caption: PropTypes.string,
-
     /**
      * Table caption position
      */
@@ -69,11 +42,6 @@ Table.propTypes = {
      * Often used with CSS to style elements with common properties
      */
     class_name: PropTypes.string,
-
-    /**
-     * Table columns
-     */
-    columns: PropTypes.arrayOf(PropTypes.string),
 
     /**
      * The ID of this component, used to identify dash components in callbacks
@@ -86,11 +54,6 @@ Table.propTypes = {
     highlightOnHover: PropTypes.bool,
 
     /**
-     * Table rows
-     */
-    rows: PropTypes.arrayOf(PropTypes.array),
-
-    /**
      * If true every odd row of table will have gray background color
      */
     striped: PropTypes.bool,
@@ -99,6 +62,11 @@ Table.propTypes = {
      * Inline style override
      */
     style: PropTypes.object,
+
+    /**
+     * Component children, specifically an HTML representation of the table
+     */
+    children: PropTypes.node,
 };
 
 export default Table;


### PR DESCRIPTION
Change `Table` component to use raw html objects. The purpose of this change is to increase flexibility (i.e. enable tables with arbitrary components; links, icons, buttons, ...) and improve alignment of dmc with mantine components. Here is a small example,

```
from dash import Dash, html
import dash_mantine_components as dmc

# region Could be moved to library (not part of this PR).

from dash.development.base_component import Component
from typing import List


def render_html_table(columns, rows=None, footers=None, caption=None) -> List[Component]:
    rows = [] if rows is None else rows
    # Create table structure.
    html_header = [html.Tr([html.Th(col) for col in columns])]
    html_rows = [html.Tr([html.Td(children=cell) for cell in row]) for row in rows]
    html_footer = [html.Tr([html.Th(col) for col in footers])]
    html_table = [html.Thead(html_header), html.Tbody(html_rows), html.Tfoot(html_footer)]
    # Add (optional) caption.
    if caption is not None:
        html_table = [html.Caption(caption)] + html_table
    # Add (optional) footer.
    if footers is not None:
        html_table += html.Tfoot(html_footer)
    return html_table


# endregion

app = Dash()
app.layout = dmc.Table(
    render_html_table(columns=["Fruit", "Price"],
                      rows=[["Apple", 1], ["Orange", 2]],
                      footers=["Fruit end", "Price end"],
                      caption="Fruits")
)

if __name__ == '__main__':
    app.run_server(port=7777)
```

![image](https://user-images.githubusercontent.com/1623542/151653857-bd9340a9-d0ed-463b-a703-181363fe2c3f.png)