### PR TITLE
Add time input component

### DIFF
--- a/src/lib/components/TimeInput.react.js
+++ b/src/lib/components/TimeInput.react.js
@@ -1,0 +1,210 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+import { TimeInput as MantineTimenInput } from "@mantine/core";
+import {renderDashComponents} from "dash-extensions-js"
+
+/**
+ * JsonInput. For more information, see: https://mantine.dev/core/json-input/
+ */
+const TimeInput = (props) => {
+    const { class_name, children, setProps } = props;
+    let nProps = omit(["setProps", "children", "class_name"], props);
+    // Render react nodes.
+    nProps = renderDashComponents(nProps, ["icon", "rightSection", "description", "error", "label"]);
+    // Bind OnChange event.
+    nProps.onChange = value => setProps({ value });
+    // Render component
+    return (
+        <MantineTimenInput
+            {...nProps}
+            className={class_name}
+        >
+            {children}
+        </MantineTimenInput>
+    );
+};
+
+TimeInput.displayName = "TimeInput";
+
+TimeInput.defaultProps = {};
+
+TimeInput.propTypes = {
+
+    /**
+    * aria-label for am/pm input
+    */
+    amPmLabel: PropTypes.string,
+
+    /**
+    * Placeholder for am/pm input
+    */
+    amPmPlaceholder: PropTypes.string,
+
+    /**
+    * aria-label for clear button
+    */
+    clearButtonLabel: PropTypes.string,
+
+    /**
+    * Allow to clear item
+    */
+    clearable: PropTypes.bool,
+
+    /**
+    * Time format
+    */
+    format: PropTypes.oneOf(["12", "24"]),
+
+    /**
+    * aria-label for hours input
+    */
+    hoursLabel: PropTypes.string,
+
+    /**
+    * Width of icon section in px
+    */
+    iconWidth: PropTypes.number,
+
+    /**
+    * aria-label for minutes input
+    */
+    minutesLabel: PropTypes.string,
+
+    /**
+    * Uncontrolled input name
+    */
+    name: PropTypes.string,
+
+    /**
+    * aria-label for seconds input
+    */
+    secondsLabel: PropTypes.string,
+
+    /**
+    * Placeholder for hours/minutes/seconds inputs
+    */
+    timePlaceholder: PropTypes.string,
+
+    /**
+    * Value for controlled input
+    */
+    value: PropTypes.string,  // TODO: Parse data?
+
+    /**
+    * Display seconds input
+    */
+    withSeconds: PropTypes.bool,
+
+    /**
+    * Default value for uncontrolled input
+    */
+    defaultValue: PropTypes.string,  // TODO: Parse date?  //X
+
+    // Input props
+
+    /**
+    * Disabled input state
+    */
+    disabled: PropTypes.bool,
+
+    /**
+    * Adds icon on the left side of input [PropTypes.node]
+    */
+    icon: PropTypes.any,
+
+    /**
+    * Sets border color to red and aria-invalid=true on input element
+    */
+    invalid: PropTypes.bool,
+
+    /**
+    * Will input have multiple lines?
+    */
+    multiline: PropTypes.bool,
+
+    /**
+    * Input border-radius from theme or number to set border-radius in px
+    */
+     radius: PropTypes.oneOfType([
+        PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+        PropTypes.number,
+    ]),
+
+    /**
+    * Right section of input, similar to icon but on the right [PropTypes.node]
+    */
+    rightSection: PropTypes.any,
+
+    /**
+    * 	Width of right section, is used to calculate input padding-right
+    */
+    rightSectionWidth: PropTypes.number,
+
+    /**
+    * Defines input appearance, defaults to default in light color scheme and filled in dark
+    */
+    variant: PropTypes.oneOf(["default", "filled", "unstyled", "headless"]),
+
+    /**
+    * Properties spread to root element
+    */
+    wrapperProps: PropTypes.any,
+
+    // InputWrapper props
+
+    /**
+    * Input description, displayed after label [PropTypes.node]
+    */
+    description: PropTypes.any,
+
+    /**
+    * Displays error message after input [PropTypes.node]
+    */
+    error: PropTypes.any,
+
+    /**
+    * Input label, displayed before input [PropTypes.node]
+    */
+    label: PropTypes.any,
+
+    /**
+    * Adds red asterisk on the right side of label
+    */
+    required: PropTypes.bool,
+
+    /**
+    * Input size
+    */
+    size: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+
+    // Dash props
+
+    /**
+    * Input that should be wrapped
+    */
+    children: PropTypes.node,
+
+    /**
+     * Often used with CSS to style elements with common properties
+     */
+    class_name: PropTypes.string,
+
+    /**
+    * The ID of this component, used to identify dash components in callbacks
+    */
+    id: PropTypes.string,
+
+    /**
+    * Tells dash if any prop has changed its value
+    */
+    setProps: PropTypes.func,
+
+    /**
+    * Inline style override
+    */
+    style: PropTypes.object,
+};
+
+
+export default TimeInput;

--- a/src/lib/components/TimeInput.react.js
+++ b/src/lib/components/TimeInput.react.js
@@ -10,7 +10,7 @@ import dayjs from "dayjs";
  */
 const TimeInput = (props) => {
     const { class_name, value, defaultValue, setProps } = props;
-    let nProps = omit(["setProps", "children", "class_name"], props);
+    let nProps = omit(["setProps", "class_name"], props);
     // Render react nodes.
     nProps = renderDashComponents(nProps, ["icon", "rightSection", "description", "error", "label"]);
     // Parse dates.

--- a/src/lib/components/TimeInput.react.js
+++ b/src/lib/components/TimeInput.react.js
@@ -17,12 +17,13 @@ const TimeInput = (props) => {
     nProps.value = new Date(value);
     nProps.defaultValue = new Date(defaultValue);
     // Bind OnChange event.
-    nProps.onChange = d => setProps({ value: d && dayjs(d).format("YYYY-MM-DDTHH:mm:ss") });
+    const onChange = d => setProps({ value: d && dayjs(d).format("YYYY-MM-DDTHH:mm:ss") });
     // Render component
     return (
         <MantineTimeInput
             {...nProps}
             className={class_name}
+            onChange={onChange}
         >
         </MantineTimeInput>
     );

--- a/src/lib/components/TimeInput.react.js
+++ b/src/lib/components/TimeInput.react.js
@@ -1,27 +1,30 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { omit } from "ramda";
-import { TimeInput as MantineTimenInput } from "@mantine/core";
+import { TimeInput as MantineTimeInput } from "@mantine/dates";
 import {renderDashComponents} from "dash-extensions-js"
+import dayjs from "dayjs";
 
 /**
- * JsonInput. For more information, see: https://mantine.dev/core/json-input/
+ * TimeInput. For more information, see: https://mantine.dev/dates/time-input/
  */
 const TimeInput = (props) => {
-    const { class_name, children, setProps } = props;
+    const { class_name, value, defaultValue, setProps } = props;
     let nProps = omit(["setProps", "children", "class_name"], props);
     // Render react nodes.
     nProps = renderDashComponents(nProps, ["icon", "rightSection", "description", "error", "label"]);
+    // Parse dates.
+    nProps.value = new Date(value);
+    nProps.defaultValue = new Date(defaultValue);
     // Bind OnChange event.
-    nProps.onChange = value => setProps({ value });
+    nProps.onChange = d => setProps({ value: d && dayjs(d).format("YYYY-MM-DDTHH:mm:ss") });
     // Render component
     return (
-        <MantineTimenInput
+        <MantineTimeInput
             {...nProps}
             className={class_name}
         >
-            {children}
-        </MantineTimenInput>
+        </MantineTimeInput>
     );
 };
 
@@ -89,7 +92,7 @@ TimeInput.propTypes = {
     /**
     * Value for controlled input
     */
-    value: PropTypes.string,  // TODO: Parse data?
+    value: PropTypes.string,
 
     /**
     * Display seconds input
@@ -99,7 +102,7 @@ TimeInput.propTypes = {
     /**
     * Default value for uncontrolled input
     */
-    defaultValue: PropTypes.string,  // TODO: Parse date?  //X
+    defaultValue: PropTypes.string,
 
     // Input props
 
@@ -179,11 +182,6 @@ TimeInput.propTypes = {
     size: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
 
     // Dash props
-
-    /**
-    * Input that should be wrapped
-    */
-    children: PropTypes.node,
 
     /**
      * Often used with CSS to style elements with common properties

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -48,6 +48,7 @@ import Navbar from "./components/Navbar.react";
 import InputWrapper from "./components/InputWrapper.react";
 import ColorPicker from "./components/ColorPicker.react";
 import MantineProvider from "./components/MantineProvider.react";
+import TimeInput from "./components/TimeInput.react";
 
 export {
     Button,
@@ -100,4 +101,5 @@ export {
     InputWrapper,
     ColorPicker,
     MantineProvider,
+    TimeInput
 };


### PR DESCRIPTION
This PR adds the [`TimeInput` component](https://mantine.dev/dates/time-input/). Here is a small example,

```
import dash_mantine_components as dmc
from dash import Dash, html, Input, Output
from datetime import datetime

app = Dash()
app.layout = html.Div([
    dmc.TimeInput(value=datetime.now().isoformat(), id="time", withSeconds=True),
    html.Div(id="log")
])


@app.callback(Output("log", "children"), Input("time", "value"))
def update(time):
    return datetime.fromisoformat(time)


if __name__ == '__main__':
    app.run_server(port=7777, debug=True)
```

![image](https://user-images.githubusercontent.com/1623542/151662144-ca34db26-97ef-42e4-aaa9-3ceea1e2ef78.png)