### PR TITLE
Add persistence props

### DIFF
--- a/src/lib/components/Checkbox.react.js
+++ b/src/lib/components/Checkbox.react.js
@@ -26,6 +26,8 @@ Checkbox.displayName = "Checkbox";
 
 Checkbox.defaultProps = {
     checked: false,
+    persisted_props: ['checked'],
+    persistence_type: 'local',
 };
 
 Checkbox.propTypes = {
@@ -73,6 +75,34 @@ Checkbox.propTypes = {
      * Checkbox label
      */
     label: PropTypes.string,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+     persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+        
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['checked'])),
+        
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),    
 
     /**
      * Radius from theme.radius, or number to set border-radius in px

--- a/src/lib/components/DatePicker.react.js
+++ b/src/lib/components/DatePicker.react.js
@@ -71,7 +71,10 @@ const DatePicker = (props) => {
 
 DatePicker.displayName = "DatePicker";
 
-DatePicker.defaultProps = {};
+DatePicker.defaultProps = {
+    persisted_props: ['value'],
+    persistence_type: 'local',
+};
 
 DatePicker.propTypes = {
     /**
@@ -228,6 +231,34 @@ DatePicker.propTypes = {
      * Will input have multiple lines?
      */
     multiline: PropTypes.bool,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+    persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+        
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+        
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 
     /**
      * Placeholder, displayed when date is not selected

--- a/src/lib/components/DateRangePicker.react.js
+++ b/src/lib/components/DateRangePicker.react.js
@@ -87,7 +87,10 @@ const DateRangePicker = (props) => {
 
 DateRangePicker.displayName = "DateRangePicker";
 
-DateRangePicker.defaultProps = {};
+DateRangePicker.defaultProps = {
+    persisted_props: ['value'],
+    persistence_type: 'local',
+};
 
 DateRangePicker.propTypes = {
     /**
@@ -245,6 +248,34 @@ DateRangePicker.propTypes = {
      */
     multiline: PropTypes.bool,
 
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+    persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+    
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+    
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
+    
     /**
      * Placeholder, displayed when date is not selected
      */

--- a/src/lib/components/MultiSelect.react.js
+++ b/src/lib/components/MultiSelect.react.js
@@ -36,6 +36,8 @@ MultiSelect.displayName = "MultiSelect";
 
 MultiSelect.defaultProps = {
     data: [],
+    persisted_props: ['value', 'data'],
+    persistence_type: 'local',
 };
 
 MultiSelect.propTypes = {
@@ -155,6 +157,34 @@ MultiSelect.propTypes = {
      * Nothing found label
      */
     nothingFound: PropTypes.string,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+    persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+    
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value', 'data',])),
+    
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 
     /**
      * Placeholder, displayed when date is not selected

--- a/src/lib/components/MultiSelect.react.js
+++ b/src/lib/components/MultiSelect.react.js
@@ -36,7 +36,7 @@ MultiSelect.displayName = "MultiSelect";
 
 MultiSelect.defaultProps = {
     data: [],
-    persisted_props: ['value', 'data'],
+    persisted_props: ['value'],
     persistence_type: 'local',
 };
 
@@ -176,7 +176,7 @@ MultiSelect.propTypes = {
      * Properties whose user interactions will persist after refreshing the
      * component or the page. 
      */
-    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value', 'data',])),
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
     
     /**
      * Where persisted user changes will be stored:

--- a/src/lib/components/RadioGroup.react.js
+++ b/src/lib/components/RadioGroup.react.js
@@ -32,7 +32,10 @@ const RadioGroup = (props) => {
 
 RadioGroup.displayName = "RadioGroup";
 
-RadioGroup.defaultProps = {};
+RadioGroup.defaultProps = {
+    persisted_props: ['value'],
+    persistence_type: 'local',
+};
 
 RadioGroup.propTypes = {
     /**
@@ -95,6 +98,34 @@ RadioGroup.propTypes = {
      * Input label, displayed before input
      */
     label: PropTypes.string,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+    persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+                
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+                
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 
     /**
      * Adds red asterisk on the right side of label

--- a/src/lib/components/Select.react.js
+++ b/src/lib/components/Select.react.js
@@ -36,6 +36,8 @@ Select.displayName = "Select";
 
 Select.defaultProps = {
     data: [],
+    persisted_props: ['value', 'data'],
+    persistence_type: 'local',
 };
 
 Select.propTypes = {
@@ -150,6 +152,34 @@ Select.propTypes = {
      * Nothing found label
      */
     nothingFound: PropTypes.string,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+     persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value', 'data',])),
+
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 
     /**
      * Placeholder, displayed when date is not selected

--- a/src/lib/components/Select.react.js
+++ b/src/lib/components/Select.react.js
@@ -36,7 +36,7 @@ Select.displayName = "Select";
 
 Select.defaultProps = {
     data: [],
-    persisted_props: ['value', 'data'],
+    persisted_props: ['value'],
     persistence_type: 'local',
 };
 
@@ -171,7 +171,7 @@ Select.propTypes = {
      * Properties whose user interactions will persist after refreshing the
      * component or the page. 
      */
-    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value', 'data',])),
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
 
     /**
      * Where persisted user changes will be stored:

--- a/src/lib/components/TimeInput.react.js
+++ b/src/lib/components/TimeInput.react.js
@@ -43,7 +43,10 @@ const TimeInput = (props) => {
 
 TimeInput.displayName = "TimeInput";
 
-TimeInput.defaultProps = {};
+TimeInput.defaultProps = {
+    persisted_props: ['value'],
+    persistence_type: 'local',
+};
 
 TimeInput.propTypes = {
     /**
@@ -120,6 +123,34 @@ TimeInput.propTypes = {
      * Uncontrolled input name
      */
     name: PropTypes.string,
+
+    /**
+     * Used to allow user interactions in this component to be persisted when
+     * the component - or the page - is refreshed. If `persisted` is truthy and
+     * hasn't changed from its previous value, a `value` that the user has
+     * changed while using the app will keep that change, as long as
+     * the new `value` also matches what was given originally.
+     * Used in conjunction with `persistence_type`.
+     */
+    persistence: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string,
+        PropTypes.number,
+    ]),
+            
+    /**
+     * Properties whose user interactions will persist after refreshing the
+     * component or the page. 
+     */
+    persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+            
+    /**
+     * Where persisted user changes will be stored:
+     * memory: only kept in memory, reset on page refresh.
+     * local: window.localStorage, data is kept after the browser quit.
+     * session: window.sessionStorage, data is cleared once the browser quit.
+     */
+    persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),    
 
     /**
      * Input border-radius from theme or number to set border-radius in px


### PR DESCRIPTION
Add persistence to the following components: Select, MultiSelect, DatePicker, DateRangePicker, TimeInput, Checkbox, RadioGroup.

I stole the docstrings from `dcc.Dropdown` with minor changes. Let me know if you prefer something shorter... If it is fine, then I will check if it makes sense to add these props to other components. 