### PR TITLE
Highlight component first implementation

### DIFF
--- a/src/lib/components/Highlight.react.js
+++ b/src/lib/components/Highlight.react.js
@@ -1,0 +1,148 @@
+import React from "react";
+import { Highlight as MantineHighlight } from '@mantine/core';
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+
+/**
+ * Highlight given part of a string with mark tag. For more information, see: https://mantine.dev/core/highlight/
+ */
+const Highlight = (props) => {
+    const { children, highlight, class_name } = props;
+
+    return (
+        <MantineHighlight
+            highlight={highlight}
+            className={class_name ? class_name : ''}
+            {...omit(["children", "highlight", 'class_name'], props)}
+        >
+            {children}
+        </MantineHighlight>
+    )
+};
+
+Highlight.displayName = "Highlight";
+
+Highlight.defaultProps = {
+    highlightColor: "yellow"
+};
+
+Highlight.propTypes = {
+    /**
+     * 	Sets text-align css property
+     */
+    align: PropTypes.oneOf(["left", "right", "center", "justify"]),
+
+    /**
+     * Full string part of which will be highlighted
+    */
+    children: PropTypes.string,
+
+    /**
+    * Often used with CSS to style elements with common properties
+    */
+    class_name: PropTypes.string,
+
+    /**
+     * Text color from theme
+     */
+    color: PropTypes.oneOf([
+        "dark",
+        "gray",
+        "red",
+        "pink",
+        "grape",
+        "violet",
+        "indigo",
+        "blue",
+        "cyan",
+        "teal",
+        "green",
+        "lime",
+        "yellow",
+        "orange",
+    ]),
+
+    // /**
+    //  * Tag or component that should be used as root element
+    //  */
+    // component: PropTypes.bool,
+
+    /**
+     * Controls gradient settings in gradient variant only
+     */
+    gradient: PropTypes.any,
+    /**
+     * Substring or an array of substrings to highlight in children
+     */
+    highlight: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string)
+    ]).isRequired,
+    /**
+     * Color from theme that is used for highlighting
+     */
+    highlightColor: PropTypes.oneOf([
+        "dark",
+        "gray",
+        "red",
+        "pink",
+        "grape",
+        "violet",
+        "indigo",
+        "blue",
+        "cyan",
+        "teal",
+        "green",
+        "lime",
+        "yellow",
+        "orange",
+    ]),
+    /**
+     * Styles applied to highlighted part
+     */
+    highlightStyles: PropTypes.object,
+    /**
+     * The ID of this component, used to identify dash components in callbacks
+    */
+    id: PropTypes.string,
+    /**
+     * Inherit font properties from parent element
+     */
+    inherit: PropTypes.bool,
+    /**
+     * Sets line-height to 1 for centering
+     */
+    inline: PropTypes.bool,
+    /**
+     * CSS -webkit-line-clamp property
+     */
+    lineClamp: PropTypes.number,
+    /**
+     * 	Predefined font-size from theme.fontSizes
+     */
+    size: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+
+    /**
+     * Inline style override
+    */
+    style: PropTypes.object,
+
+    /**
+     * Sets text-transform css property
+     */
+    transform: PropTypes.oneOf(["none", "capitalize", "lowercase", "uppercase"]),
+    /**
+     * Underline the text
+     */
+    underline: PropTypes.bool,
+    /**
+     * Link or text variant
+     */
+    variant: PropTypes.oneOf(["link", "text", "gradient"]),
+    /**
+     * Sets font-weight css property
+     */
+    weight: PropTypes.string,
+};
+
+export default Highlight;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -58,6 +58,7 @@ import LoadingOverlay from "./components/LoadingOverlay.react";
 import Avatar from "./components/Avatar.react";
 import AvatarGroup from "./components/AvatarGroup.react";
 import Kbd from "./components/Kbd.react";
+import Highlight from "./components/Highlight.react";
 
 export {
     Button,
@@ -120,4 +121,5 @@ export {
     Avatar,
     AvatarGroup,
     Kbd,
+    Highlight
 };


### PR DESCRIPTION
How can I add the prop Component? 

![image](https://user-images.githubusercontent.com/24701735/155902599-85ac5226-a359-4dba-acd7-e97660f1b9d9.png)

To test the component you can use the below snippet:

```

import dash
from dash import html
import dash_mantine_components as dmc

app = dash.Dash(__name__)

app.layout = html.Div(
    className="text-center",
    children=[
        html.Div([
            html.Div("Highlight Component test"),
            dmc.Highlight(children="Highlight This, definitely THIS and also this!", 
                          highlight="this", 
                          align="right", size="xl",
                        #   transform="uppercase", 
                        #   underline=True, 
                          inherit=False,
                          color="red",
                          inline=True,
                          highlightColor="green")
        ]),
    ],
    style={"padding": "64px"},
)

if __name__ == "__main__":
    app.run_server(debug=True, port=9966)
```