### PR TITLE
Converting Media query component - working

### DIFF
--- a/src/lib/components/MediaQuery.react.js
+++ b/src/lib/components/MediaQuery.react.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, MediaQuery as MantineMediaQuery } from '@mantine/core';
+import { Box, Text, MediaQuery as MantineMediaQuery } from '@mantine/core';
 import PropTypes from "prop-types";
 import { omit } from "ramda";
 
@@ -8,26 +8,40 @@ import { omit } from "ramda";
  */
 const MediaQuery = (props) => {
 
-    const { children, class_name, styles, boxSx } = props;
+    const { children, class_name, styles, boxSx, contentBox } = props;
+    const children_type = children.props._dashprivate_layout.type
+
+    if (contentBox === true && children_type === "Text") {
+        return (
+            <MantineMediaQuery
+                {...omit(["children", "class_name",
+                    "styles", "boxSx", "contentBox"], props)}
+                className={class_name}
+                styles={styles}
+            >
+                <Box sx={boxSx}>
+                    {children}
+                </Box>
 
 
-    console.log(props, children)
-    console.log(children.props._dashprivate_layout.props)
-    return (
-        <MantineMediaQuery
-            largerThan={800}
-            {...omit(["children", "class_name",
-                "styles", "boxSx", "contentBox"], props)}
-            className={class_name}
-            styles={styles}
-
-        >
-            <Box sx={boxSx}>
-                {children}
-            </Box>
-
-        </MantineMediaQuery>
-    );
+            </MantineMediaQuery>
+        );
+    } else if (children_type === "Text") {
+        return (
+            <MantineMediaQuery
+                {...omit(["children", "class_name",
+                    "styles", "boxSx", "contentBox"], props)}
+                className={class_name}
+                styles={styles}
+            >
+                <Text sx={boxSx}>
+                    {children}
+                </Text>
+            </MantineMediaQuery>
+        )
+    }
+    return Error(
+        `MediaQuery Component only accepts dmc.Text components, and you can flag if it should be a Box component or not.`);
 };
 
 MediaQuery.displayName = "MediaQuery";

--- a/src/lib/components/MediaQuery.react.js
+++ b/src/lib/components/MediaQuery.react.js
@@ -1,0 +1,104 @@
+import React from "react";
+import { Box, MediaQuery as MantineMediaQuery } from '@mantine/core';
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+
+/**
+ * Apply styles to children if media query matches. For more information, see: https://mantine.dev/core/media-query/
+ */
+const MediaQuery = (props) => {
+
+    const { children, class_name, styles, boxSx } = props;
+
+
+    console.log(props, children)
+    console.log(children.props._dashprivate_layout.props)
+    return (
+        <MantineMediaQuery
+            largerThan={800}
+            {...omit(["children", "class_name",
+                "styles", "boxSx", "contentBox"], props)}
+            className={class_name}
+            styles={styles}
+
+        >
+            <Box sx={boxSx}>
+                {children}
+            </Box>
+
+        </MantineMediaQuery>
+    );
+};
+
+MediaQuery.displayName = "MediaQuery";
+
+MediaQuery.defaultProps = {};
+
+MediaQuery.propTypes = {
+    /**
+    * Child that should be shown at given breakpoint, it must accept className prop
+    */
+    children: PropTypes.node,
+
+    /**
+     * Often used with CSS to style elements with common properties
+    */
+    class_name: PropTypes.string,
+
+    /**
+     * The ID of this component, used to identify dash components in callbacks
+     */
+    id: PropTypes.string,
+
+    /**
+    * Styles applied to child when viewport is larger than given breakpoint
+    */
+    largerThan: PropTypes.oneOfType([
+        PropTypes.oneOf([
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+        ]),
+        PropTypes.number,
+    ]),
+
+    /**
+    * Any other media query
+    */
+    query: PropTypes.string,
+
+    /**
+    * 	Styles applied to child when viewport is smaller than given breakpoint
+    */
+    smallerThan: PropTypes.oneOfType([
+        PropTypes.oneOf([
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+        ]),
+        PropTypes.number,
+    ]),
+
+    // /**
+    //  * Inline style override
+    // */
+    // style: PropTypes.object,
+
+    /**
+     * The style that will be set if condition is met
+    */
+    styles: PropTypes.object,
+
+    /**
+    * If the content will be shown in the Mantine Box component
+    */
+    contentBox: PropTypes.bool,
+
+    boxSx: PropTypes.object
+};
+
+export default MediaQuery;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -61,6 +61,7 @@ import Kbd from "./components/Kbd.react";
 import Highlight from "./components/Highlight.react";
 import Timeline from "./components/Timeline.react";
 import TimelineItem from "./components/TimelineItem.react";
+import MediaQuery from "./components/MediaQuery.react";
 
 export {
     Button,
@@ -126,4 +127,5 @@ export {
     Highlight,
     Timeline,
     TimelineItem,
+    MediaQuery
 };


### PR DESCRIPTION
It's the Mantine MediaQuery component.

I did create 2 new extra props to define if it is a box or not and to add the style in the internal/content component... But based on the Mantine Documentation I think that it would be more appropriate for me to create a condition to Text and for Box options. 

I'm open to knowing and testing different alternatives to implement here. 

```
import dash
from dash import dcc, html, Input, Output
import dash_mantine_components as dmc

app = dash.Dash(__name__)

app.layout = html.Div(
    className="text-center",
    children=[
        html.Div([
            dmc.MantineProvider(
                theme={"colorScheme": "dark"},
                children=[
                    dmc.MediaQuery(children=dmc.Text(["Testing MediaQuuery Component"]), 
                           query="(max-width: 1200px) and (min-width: 800px)",
                           styles={"fontSize": 20, 'backgroundColor':"green"},
                           boxSx={"color":"blue"}, contentBox=True)
                ],
            ),
            dmc.MediaQuery(children=dmc.Text(["Testing second Mediaquery."]), 
                           largerThan="md", 
                           styles={"color":"red", "border":"1px solid black"},
                           boxSx={"color":"red"})

        ]),
    ],
    style={"padding": "64px"},
)

if __name__ == "__main__":
    app.run_server(debug=True, port=9966)
```
