### PR TITLE
Adding component Mark

### DIFF
--- a/src/lib/components/Mark.react.js
+++ b/src/lib/components/Mark.react.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Mark as MantineMark } from '@mantine/core';
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+
+
+/**
+* Highlight part of the text. For more information, see: https://mantine.dev/core/mark/
+*/
+const Mark = (props) => {
+
+    const { children } = props;
+
+    return (
+        <MantineMark
+            {...omit(["children",], props)}
+        >
+            {children}
+        </MantineMark>
+    )
+};
+
+
+Mark.displayName = "Mark";
+
+Mark.defaultProps = {
+    color: "yellow"
+};
+
+Mark.propTypes = {
+    /**
+    * Full string part of which will be highlighted
+    */
+    children: PropTypes.string,
+
+    /**
+    * Background color from theme.colors
+    */
+    color: PropTypes.oneOf([
+        "dark",
+        "gray",
+        "red",
+        "pink",
+        "grape",
+        "violet",
+        "indigo",
+        "blue",
+        "cyan",
+        "teal",
+        "green",
+        "lime",
+        "yellow",
+        "orange",
+    ]),
+
+    /**
+     * The ID of this component, used to identify dash components in callbacks
+     */
+    id: PropTypes.string
+
+};
+
+export default Mark;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -64,6 +64,7 @@ import TimelineItem from "./components/TimelineItem.react";
 import Menu from "./components/Menu.react";
 import MenuItem from "./components/MenuItem.react";
 import MenuLabel from "./components/MenuLabel.react";
+import Mark from "./components/Mark.react";
 
 export {
     Button,
@@ -132,4 +133,5 @@ export {
     Menu,
     MenuItem,
     MenuLabel,
+    Mark
 };


### PR DESCRIPTION
It's a simple component that highlights a text

![image](https://user-images.githubusercontent.com/24701735/156861405-b3dd019a-9359-4f6c-a74a-3d6ea745ff9e.png)

```
from datetime import datetime, date

import dash_mantine_components as dmc
from dash import Input, Output, html
import dash

app = dash.Dash(__name__)

app.layout=html.Div(
    [
        # dmc.TransferList(value=[[],[]]),
        html.Div(["Hellow, testing ", dmc.Mark(" Mark component ", color="grape"), " as a test." ]),
    ]
)

if __name__ == "__main__":
    app.run_server(debug=True, port=9966)
```

