### PR TITLE
Fixes bug; chip disabled state not passed to component

### DIFF
--- a/src/lib/components/Chips.react.js
+++ b/src/lib/components/Chips.react.js
@@ -21,7 +21,7 @@ const Chips = (props) => {
         >
             {data.map((chip, index) => {
                 return (
-                    <Chip value={chip.value} key={index}>
+                    <Chip disabled={chip.disabled} value={chip.value} key={index}>
                         {chip.label}
                     </Chip>
                 );


### PR DESCRIPTION
Currently, it is not possible to set the `disabled` state for chips, as the state is not passed to the react layer. This PR fixes the bug.

```
from dash import Dash
import dash_mantine_components as dmc

app = Dash()
app.layout = dmc.Chips(
    data=[{"value": c, "label": c, "disabled": c == "£"} for c in ["€", "£", "$", "¥"]]
)

app.run_server(port=7779)
```