### PR TITLE
pagination component full convertion

### DIFF
--- a/src/lib/components/Pagination.react.js
+++ b/src/lib/components/Pagination.react.js
@@ -1,0 +1,159 @@
+import React from "react";
+import { Pagination as MantinePagination } from '@mantine/core';
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+
+/**
+ * Display active page and navigate between multiple pages. For more information, see: https://mantine.dev/core/pagination/
+*/
+const Pagination = (props) => {
+
+    const { setProps, class_name } = props;
+
+    return (
+        <MantinePagination
+            {...omit(["setProps", "class_name"], props)}
+            onChange={(page) => setProps({ page })}
+            className={class_name}
+        >
+        </MantinePagination>
+    );
+};
+
+Pagination.displayName = "Pagination";
+
+Pagination.defaultProps = { page: 1 };
+
+Pagination.propTypes = {
+    /**
+     * 	Defines align-items css property
+    */
+    align: PropTypes.oneOf(["stretch", "center", "flex-end", "flex-start"]),
+    /**
+     * Amount of elements visible on left/right edges
+    */
+    boundaries: PropTypes.number,
+
+    /**
+     * Often used with CSS to style elements with common properties
+    */
+    class_name: PropTypes.string,
+    /**
+     * Active item color from theme, defaults to theme.primaryColor
+    */
+    color: PropTypes.oneOf([
+        "dark",
+        "gray",
+        "red",
+        "pink",
+        "grape",
+        "violet",
+        "indigo",
+        "blue",
+        "cyan",
+        "teal",
+        "green",
+        "lime",
+        "yellow",
+        "orange",
+    ]),
+    /**
+     * Defines flex-direction property, row for horizontal, column for vertical
+    */
+    direction: PropTypes.oneOf(["row", "column"]),
+    /**
+     * Callback to control aria-labels
+    */
+    getItemAriaLabel: PropTypes.oneOfType([
+        PropTypes.oneOf([
+            "dots",
+            "first",
+            "last",
+            "next",
+            "prev",
+        ]),
+        PropTypes.number,
+    ]),
+    /**
+     * Defines flex-grow property for each element, true -> 1, false -> 0
+    */
+    grow: PropTypes.bool,
+    /**
+     * The ID of this component, used to identify dash components in callbacks
+    */
+    id: PropTypes.string,
+    /**
+     * 	Active initial page for uncontrolled component
+    */
+    initialPage: PropTypes.number,
+    /**
+     * Change item component
+    */
+    itemComponent: PropTypes.any,
+    /**
+     * 	Defined flex-wrap property
+    */
+    noWrap: PropTypes.bool,
+    /**
+     * 	Callback fired after change of each page
+    */
+    onChange: PropTypes.node,
+    /**
+     * Controlled active page number
+    */
+    page: PropTypes.number,
+    /**
+     * Defines justify-content property
+    */
+    position: PropTypes.oneOf([
+        "right",
+        "center",
+        "left",
+        "apart",
+    ]),
+    /**
+     * Predefined item radius or number to set border-radius in px
+    */
+    radius: PropTypes.oneOfType([
+        PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+        PropTypes.number,
+    ]),
+    /**
+     * Tells dash if any prop has changed its value
+     */
+    setProps: PropTypes.func,
+    /**
+     * Siblings amount on left/right side of selected page
+    */
+    siblings: PropTypes.number,
+    /**
+     * Predefined item size or number to set width and height in px
+    */
+    size: PropTypes.oneOfType([
+        PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+        PropTypes.number,
+    ]),
+    /**
+     * Spacing between items from theme or number to set value in px, defaults to theme.spacing.xs / 2
+    */
+    spacing: PropTypes.oneOfType([
+        PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+        PropTypes.number,
+    ]),
+
+    style: PropTypes.object,
+    /**
+     * Total amount of pages
+    */
+    total: PropTypes.number,
+    /**
+     * Show/hide prev/next controls
+    */
+    withControls: PropTypes.bool,
+    /**
+     * Show/hide jump to start/end controls
+    */
+    withEdges: PropTypes.bool,
+};
+
+export default Pagination;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -73,6 +73,7 @@ import BackgroundImage from "./components/BackgroundImage.react";
 import DemoSlider from "./components/DemoSlider.react";
 import ActionIcon from "./components/ActionIcon.react";
 import ThemeSwitcher from "./components/ThemeSwitcher.react";
+import Pagination from "./components/Pagination.react";
 
 export {
     Button,
@@ -150,4 +151,5 @@ export {
     DemoSlider,
     ActionIcon,
     ThemeSwitcher,
+    Pagination
 };


### PR DESCRIPTION
Mantine Pagination component:

![dmc-pagination-component](https://user-images.githubusercontent.com/24701735/169715051-82907480-4425-4449-b191-d2c5e8585ea1.gif)

To test and reproduce the component you can use the following code snippet:
```
import dash
from dash import dcc, html, Input, Output
import dash_mantine_components as dmc

external_stylesheets = ["https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"]
app = dash.Dash(__name__, external_stylesheets=external_stylesheets)

app.layout = html.Div(
    className="text-center",
    children=[
        html.Div([html.B("DMC - Dash Mantine Components")]),
        html.Div("Pagination component"),
        dmc.Pagination(
            id="dmc-pagination-page",
            total=25,
            page=14,
            position="center",
            siblings=2,
            boundaries=1,
            align="stretch",
            radius="lg",
            size="md",
            direction="row",
            withEdges=False,
            withControls=True,
            color="red",
            style={"marginTop": "32px"},
        ),
        html.Div(id="my-custom-component", style={"marginTop": "32px"}),
    ],
    style={"padding": "64px"},
)

@app.callback(
    Output("my-custom-component", "children"),
    [Input("dmc-pagination-page", "page")],
)
def display_input_value(value):
    return f"Page selected value is {value}"


if __name__ == "__main__":
    app.run_server(debug=True, port=9966)
```
