### PR TITLE
stack component ready

### DIFF
--- a/src/lib/components/Stack.react.js
+++ b/src/lib/components/Stack.react.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { Stack as MantineStack } from "@mantine/core";
+import PropTypes from "prop-types";
+import { omit } from "ramda";
+
+/**
+ * Compose elements and components in vertical flex container. For more information, see: https://mantine.dev/core/Stack/
+ */
+const Stack = (props) => {
+    const { children, class_name } = props;
+    return (
+        <MantineStack
+            className={class_name}
+            {...omit(["setProps", "children", "class_name"], props)}
+        >
+            {children}
+        </MantineStack>
+    );
+};
+
+Stack.displayName = "Stack";
+
+Stack.defaultProps = {};
+
+Stack.propTypes = {
+    /**
+     * 	Sets text-align css property
+    */
+    align: PropTypes.oneOf(["stretch", "center", "flex-end", "flex-start"]),
+    /**
+     * Primary content inside the stack
+    */
+    children: PropTypes.node,
+    /**
+     * Often used with CSS to style elements with common properties
+     */
+    class_name: PropTypes.string,
+    /**
+     * Set grid justify-content property
+    */
+    justify: PropTypes.oneOf([
+        "space-between",
+        "space-around",
+        "center",
+        "flex-end",
+        "flex-start",
+    ]),
+    /**
+     * Spacing between avatars
+     */
+    spacing: PropTypes.oneOfType([
+        PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+        PropTypes.number,
+    ]),
+    /**
+     * Inline style
+     */
+    style: PropTypes.object,
+};
+
+export default Stack;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -73,6 +73,7 @@ import BackgroundImage from "./components/BackgroundImage.react";
 import DemoSlider from "./components/DemoSlider.react";
 import ActionIcon from "./components/ActionIcon.react";
 import ThemeSwitcher from "./components/ThemeSwitcher.react";
+import Stack from "./components/Stack.react";
 
 export {
     Button,
@@ -150,4 +151,5 @@ export {
     DemoSlider,
     ActionIcon,
     ThemeSwitcher,
+    Stack,
 };


### PR DESCRIPTION
I have converted the Mantine Stack Component:

![image](https://user-images.githubusercontent.com/24701735/169715331-6f66e1a9-4cad-433a-ba24-66a9d4330a13.png)


To reproduce and test the component, you can use the following snippet:
```
import dash
from dash import dcc, html, Input, Output
import dash_mantine_components as dmc

external_stylesheets = ["https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"]
app = dash.Dash(__name__, external_stylesheets=external_stylesheets)

app.layout = html.Div(
    className="text-center",
    children=[
        html.Div([html.B("DMC - Dash Mantine Components")]),
        html.Div("Stack component"),
        dmc.Stack(
            [
                dmc.Button("Btn Component 1"),
                dmc.Button("Btn Component 2"),
                dmc.Button("Btn Component 3"),
                dmc.Button("Btn Component 4"),
            ],
            justify="space-around",
            align="center",
            spacing="xl",
            style={
                "height": "250px",
                "backgroundColor": "lightgrey",
                "marginTop": "32px",
            },
        ),
        html.Div(id="my-custom-component", style={"marginTop": "32px"}),
    ],
    style={"padding": "64px"},
)

if __name__ == "__main__":
    app.run_server(debug=True, port=9966)
```
