### PR TITLE
Added Burger and AppShell dash components

### DIFF
--- a/src/ts/components/core/Burger.tsx
+++ b/src/ts/components/core/Burger.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { DefaultProps } from "../../props";
+import { Burger as MantineBurger } from "@mantine/core";
+import { MantineNumberSize } from "@mantine/styles";
+
+type BurgerProps = {
+    /** Burger state: true for cross, false for burger */
+    opened: boolean;
+    /** Burger color value, not connected to theme.colors, defaults to theme.black with light color scheme and theme.white with dark */
+    color?: string;
+    /** Predefined burger size or number to set width and height in px */
+    size?: MantineNumberSize;
+    /** Transition duration in ms */
+    transitionDuration?: number;
+} & DefaultProps;
+
+/**
+ * Display burger-style menu button. For more information, see: https://mantine.dev/core/burger/
+ */
+const Burger = (props: BurgerProps) => {
+    const { setProps, opened, ...other } = props;
+
+    const onClick = () => {
+        setProps({
+            opened: !opened,
+        });
+    };
+
+    return <MantineBurger onClick={onClick} opened={opened} {...other} />;
+};
+
+Burger.defaultProps = {
+    opened: false,
+    size: 'md',
+    transitionDuration: 300,
+};
+
+export default Burger;

--- a/src/ts/components/core/appshell/AppShell.tsx
+++ b/src/ts/components/core/appshell/AppShell.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { DefaultProps } from "../../../props";
+import { AppShell as MantineAppShell } from "@mantine/core";
+import { MantineNumberSize } from "@mantine/styles";
+
+type Props = {
+    /** <Navbar /> component */
+    navbar?: JSX.Element;
+    /** <Aside /> component */
+    aside?: JSX.Element;
+    /** <Header /> component */
+    header?: JSX.Element;
+    /** <Footer /> component */
+    footer?: JSX.Element;
+    /** zIndex prop passed to Navbar and Header components */
+    zIndex?: React.CSSProperties['zIndex'];
+    /** true to switch from static layout to fixed */
+    fixed?: boolean;
+    /** true to hide all AppShell parts and render only children */
+    hidden?: boolean;
+    /** AppShell content */
+    children: React.ReactNode;
+    /** Content padding */
+    padding?: MantineNumberSize;
+    /** Breakpoint at which Navbar component should no longer be offset with padding-left, applicable only for fixed position */
+    navbarOffsetBreakpoint?: MantineNumberSize;
+    /** Breakpoint at which Aside component should no longer be offset with padding-right, applicable only for fixed position */
+    asideOffsetBreakpoint?: MantineNumberSize;
+} & DefaultProps;
+
+/**
+ * Layout component to create a popular Header - Navbar - Footer - Aside - Content layout pattern. For more information, see: https://mantine.dev/core/app-shell/
+ */
+const AppShell = (props: Props) => {
+    const {children, ...other } = props;
+
+    return <MantineAppShell {...other}>{children}</MantineAppShell>
+}
+
+AppShell.defaultProps = {};
+
+export default AppShell;

--- a/src/ts/components/core/appshell/AppShell.tsx
+++ b/src/ts/components/core/appshell/AppShell.tsx
@@ -32,7 +32,7 @@ type Props = {
  * Layout component to create a popular Header - Navbar - Footer - Aside - Content layout pattern. For more information, see: https://mantine.dev/core/app-shell/
  */
 const AppShell = (props: Props) => {
-    const {children, ...other } = props;
+    const {children, setProps, ...other } = props;
 
     return <MantineAppShell {...other}>{children}</MantineAppShell>
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -7,12 +7,14 @@ import ActionIcon from "./components/core/ActionIcon";
 import Affix from "./components/core/Affix";
 import Alert from "./components/core/Alert";
 import Anchor from "./components/core/Anchor";
+import AppShell from "./components/core/appshell/AppShell";
 import Avatar from "./components/core/avatar/Avatar";
 import AvatarGroup from "./components/core/avatar/AvatarGroup";
 import Badge from "./components/core/Badge";
 import BackgroundImage from "./components/core/BackgroundImage";
 import Blockquote from "./components/core/Blockquote";
 import Breadcrumbs from "./components/core/Breadcrumbs";
+import Burger from "./components/core/Burger";
 import Button from "./components/core/button/Button";
 import ButtonGroup from "./components/core/button/ButtonGroup";
 import Center from "./components/core/Center";
@@ -104,12 +106,14 @@ export {
     Affix,
     Alert,
     Anchor,
+    AppShell,
     Avatar,
     AvatarGroup,
     Badge,
     BackgroundImage,
     Blockquote,
     Breadcrumbs,
+    Burger,
     Button,
     ButtonGroup,
     Center,


### PR DESCRIPTION
I've added a couple of additional Mantine components (AppShell and Burger) that I needed for a dash project that will hopefully be useful to others.

Here is a dash example (based off [this example](https://mantine.dev/core/app-shell/#responsive-styles)) that creates a responsive AppShell and uses the Burger menu, along with a couple of screenshots.

![Appshell3](https://user-images.githubusercontent.com/1356497/196587123-6b78bd79-7faa-4146-b71f-5e87c60cc4a6.png)
![Appshell2](https://user-images.githubusercontent.com/1356497/196587119-79dc1bde-87de-42ae-912d-2f39152e0d4e.png)
![Appshell1](https://user-images.githubusercontent.com/1356497/196587109-800176cb-2ae6-4215-ab46-341423a0d74c.png)

```python
import dash_mantine_components as dmc
from dash import Dash, html
from dash.dependencies import Input, Output

app = Dash(__name__)

navbar = dmc.Navbar(
    id="navbar",
    p="md",
    hiddenBreakpoint="sm",
    hidden=True,
    width={"sm": 200, "lg": 300},
    children="Application navbar",
)
aside = dmc.MediaQuery(
    smallerThan="sm",
    styles={"display": "none"},
    children=dmc.Aside(p="md", hiddenBreakpoint="sm", children="Application sidebar", width={"sm": 200, "lg": 300}),
)
footer = dmc.Footer(height=60, p="md", children="Application footer")
header = dmc.Header(
    height=70,
    p="md",
    children=html.Div(
        style={"display": "flex", "alignItems": "center", "height": "100%"},
        children=[
            dmc.MediaQuery(
                largerThan="sm",
                styles={"display": "none"},
                children=dmc.Burger(id="burger", opened=False, size="sm", color="gray", mr="xl"),
            ),
            "Application header",
        ],
    ),
)

color_scheme = "dark"

appshell = dmc.AppShell(
    styles={
        "main": {
            "background": "#1A1B1E" if color_scheme == "dark" else "#f8f9fa",
        },
    },
    navbarOffsetBreakpoint="sm",
    asideOffsetBreakpoint="sm",
    navbar=navbar,
    aside=aside,
    footer=footer,
    header=header,
    children=[
        html.P("Resize app to see responsive navbar in action"),
    ],
)

app.layout = dmc.MantineProvider(
    withNormalizeCSS=True, withGlobalStyles=True, theme={"colorScheme": color_scheme}, children=appshell
)


@app.callback(Output("navbar", "hidden"), [Input("burger", "opened")])
def toggle_navbar(opened):
    return not opened


if __name__ == "__main__":
    app.run_server(debug=True)
```