### PR TITLE
Fix CheckboxGroup default selection

### DIFF
--- a/src/ts/components/core/checkbox/CheckboxGroup.tsx
+++ b/src/ts/components/core/checkbox/CheckboxGroup.tsx
@@ -43,7 +43,7 @@ const CheckboxGroup = (props: Props) => {
     };
 
     return (
-        <Checkbox.Group onChange={onChange} {...other}>
+        <Checkbox.Group onChange={onChange} defaultValue={value} {...other}>
             {children}
         </Checkbox.Group>
     );


### PR DESCRIPTION
This PR fixes the bug [#140](https://github.com/snehilvj/dash-mantine-components/issues/140). After applying the fix, the default selections are now reflected correctly.

![image](https://user-images.githubusercontent.com/1623542/212875692-7a6a7b37-00a6-4973-9185-fb6981415a8f.png)
