### PR TITLE
Implements Issue #173: Add n_submits property to TextInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dash_mantine_components",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dash_mantine_components",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "license": "MIT",
             "dependencies": {
                 "@emotion/react": "^11.10.4",

--- a/src/ts/components/core/textinput/TextInput.tsx
+++ b/src/ts/components/core/textinput/TextInput.tsx
@@ -14,6 +14,8 @@ type Props = {
     value?: string;
     /** Spell check property */
     spellCheck?: boolean;
+    /** An integer that represents the number of times that this element has been submitted */
+    n_submit?: number;
 } & InputComponentProps &
     PersistenceProps &
     DefaultProps;
@@ -29,6 +31,8 @@ const TextInput = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
+        disabled,
+        n_submit,
         ...other
     } = props;
 
@@ -42,6 +46,14 @@ const TextInput = (props: Props) => {
     useDidUpdate(() => {
         setVal(value);
     }, [value]);
+    
+    const increment = () => {
+        if (!disabled) {
+            setProps({
+                n_submit: n_submit + 1,
+            });
+        }
+    };
 
     return (
         <MantineTextInput
@@ -49,6 +61,7 @@ const TextInput = (props: Props) => {
             value={val}
             wrapperProps={{ autoComplete: "off" }}
             onChange={(ev) => setVal(ev.currentTarget.value)}
+            onSubmit={increment}
         />
     );
 };
@@ -58,6 +71,7 @@ TextInput.defaultProps = {
     debounce: 0,
     persisted_props: ["value"],
     persistence_type: "local",
+    n_submit: 0,
 };
 
 export default TextInput;

--- a/src/ts/components/core/textinput/TextInput.tsx
+++ b/src/ts/components/core/textinput/TextInput.tsx
@@ -47,11 +47,9 @@ const TextInput = (props: Props) => {
         setVal(value);
     }, [value]);
     
-    const increment = () => {
-        if (!disabled) {
-            setProps({
-                n_submit: n_submit + 1,
-            });
+    const handleKeyDown = (ev) => {
+        if (ev.key === 'Enter') {
+            setProps({ n_submit: n_submit + 1 });
         }
     };
 
@@ -61,7 +59,7 @@ const TextInput = (props: Props) => {
             value={val}
             wrapperProps={{ autoComplete: "off" }}
             onChange={(ev) => setVal(ev.currentTarget.value)}
-            onSubmit={increment}
+            onKeyDown={handleKeyDown}
         />
     );
 };


### PR DESCRIPTION
This implements the issue I raised on the Discord and then in #173. Essentially, the goal is to be able to replicate the behavior of [dcc.Input](https://dash.plotly.com/dash-core-components/input), specifically how it handles what it calls `n_submit`, which looking through their source code is essentially just incrementing a count of the number of times the enter key has been pressed.

I've gotten this working locally on my end. It seems like a pretty trivial change... but these are also the first lines of TypeScript that I've ever written, so feel free to let me know if there are any issues here. Really love the package and use it for everything, so I'm happy to have gotten a reason to dig a little deeper into how it all works.

MRE:
```
from dash import Dash, html, callback, Output, Input, State
import dash_mantine_components as dmc

app = Dash(__name__)

app.layout = html.Div([
    dmc.TextInput(id='text-input'),
    dmc.Text('Nothing yet submitted', id='text-output')
])

@callback(
    Output('text-output', 'children'),
    Input('text-input', 'n_submit'),
    State('text-input', 'value'),
    prevent_initial_call=True
)
def test_textinput_n_submit(n_submit, text_input):
    return text_input

if __name__ == '__main__':
    app.run_server(debug=True)
```