### PR TITLE
Fix datetime format that was messing with PM time values

### DIFF
--- a/src/ts/utils/dates.ts
+++ b/src/ts/utils/dates.ts
@@ -14,7 +14,7 @@ export const dateToString = (d: DateValue) => {
 
 // convert to datetime string for dash
 export const datetimeToString = (d: DateValue) => {
-    return d ? dayjs(d).format("YYYY-MM-DD hh:mm:ss") : null;
+    return d ? dayjs(d).format("YYYY-MM-DD HH:mm:ss") : null;
 };
 
 // is the date in the list of disabled dates


### PR DESCRIPTION
Formatting with `hh` makes the PM times go back to AM in the datetimepicker.