### PR TITLE
fix(import): add missing import to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pip install dash-mantine-components
 ```python
 from datetime import date
 
+import dash
 from dash import Dash, Input, Output, callback, html
 from dash.exceptions import PreventUpdate
 


### PR DESCRIPTION
**Issue**: The following line throw a missing import error.

```python
dash._dash_renderer._set_react_version('18.2.0')
``` 

**Solution**: Fixed missing `import dash` statement to README example.