### PR TITLE
fix loading state props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Added `autoplay` prop to the `Carousel` component #316 by @mmarfat 
 
+### Fixed
+
+- Excluded the `loading_state` prop from being passed to the DOM.   Added `data-dash-is-loading` attribute to
+components during callback execution, allowing custom CSS styling for loading states. #325 by @AnnMarieW
+
+
 # 0.14.5 
 
 ### Fixed

--- a/src/ts/components/charts/AreaChart.tsx
+++ b/src/ts/components/charts/AreaChart.tsx
@@ -53,7 +53,7 @@ interface Props
 
 /** AreaChart */
 const AreaChart = (props: Props) => {
-    const { setProps, clickData, areaChartProps, ...others } = props;
+    const { setProps, loading_state, clickData, areaChartProps, ...others } = props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -63,8 +63,14 @@ const AreaChart = (props: Props) => {
 
     const newProps = { ...areaChartProps, onClick };
 
-    return <MantineAreaChart areaChartProps={newProps} {...others} />;
-};
+    return (
+      <MantineAreaChart
+        data-dash-is-loading={(loading_state && loading_state.is_loading) || undefined}
+        areaChartProps={newProps}
+        {...others}
+      />
+    );
+}
 
 AreaChart.defaultProps = {};
 

--- a/src/ts/components/charts/BarChart.tsx
+++ b/src/ts/components/charts/BarChart.tsx
@@ -37,12 +37,12 @@ interface Props
     /** Determines whether a label with bar value should be displayed on top of each bar,
      incompatible with type="stacked" and type="percent", false by default */
     withBarValueLabel?: boolean;
-
 }
 
 /** BarChart */
 const BarChart = (props: Props) => {
-    const { setProps, clickData, barChartProps, ...others } = props;
+    const { setProps, loading_state, clickData, barChartProps, ...others } =
+        props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -52,11 +52,19 @@ const BarChart = (props: Props) => {
 
     const newProps = { ...barChartProps, onClick };
 
-    return <MantineBarChart barChartProps={newProps}  {...others} />;
+    return (
+        <MantineBarChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            barChartProps={newProps}
+            {...others}
+        />
+    );
 };
 
 BarChart.defaultProps = {
-    withBarValueLabel: false
+    withBarValueLabel: false,
 };
 
 export default BarChart;

--- a/src/ts/components/charts/DonutChart.tsx
+++ b/src/ts/components/charts/DonutChart.tsx
@@ -52,7 +52,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** DonutChart */
 const DonutChart = (props: Props) => {
-    const { setProps, clickData, pieProps, ...others } = props;
+    const { setProps, loading_state, clickData, pieProps, ...others } = props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -62,7 +62,15 @@ const DonutChart = (props: Props) => {
 
     const newProps = { ...pieProps, onClick };
 
-    return <MantineDonutChart pieProps={newProps} {...others} />;
+    return (
+        <MantineDonutChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            pieProps={newProps}
+            {...others}
+        />
+    );
 };
 
 DonutChart.defaultProps = {};

--- a/src/ts/components/charts/LineChart.tsx
+++ b/src/ts/components/charts/LineChart.tsx
@@ -43,7 +43,8 @@ interface Props
 
 /** LineChart */
 const LineChart = (props: Props) => {
-    const { setProps, clickData, lineChartProps, ...others } = props;
+    const { setProps, loading_state, clickData, lineChartProps, ...others } =
+        props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -53,7 +54,15 @@ const LineChart = (props: Props) => {
 
     const newProps = { ...lineChartProps, onClick };
 
-    return <MantineLineChart lineChartProps={newProps} {...others} />;
+    return (
+        <MantineLineChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            lineChartProps={newProps}
+            {...others}
+        />
+    );
 };
 
 LineChart.defaultProps = {};

--- a/src/ts/components/charts/PieChart.tsx
+++ b/src/ts/components/charts/PieChart.tsx
@@ -52,7 +52,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** PieChart */
 const PieChart = (props: Props) => {
-    const { setProps, clickData, pieProps, ...others } = props;
+    const { setProps, loading_state, clickData, pieProps, ...others } = props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -62,7 +62,15 @@ const PieChart = (props: Props) => {
 
     const newProps = { ...pieProps, onClick };
 
-    return <MantinePieChart pieProps={newProps} {...others} />;
+    return (
+        <MantinePieChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            pieProps={newProps}
+            {...others}
+        />
+    );
 };
 
 PieChart.defaultProps = {};

--- a/src/ts/components/charts/RadarChart.tsx
+++ b/src/ts/components/charts/RadarChart.tsx
@@ -40,7 +40,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** RadarChart */
 const RadarChart = (props: Props) => {
-    const { setProps, clickData, radarChartProps, ...others } = props;
+    const { setProps, loading_state, clickData, radarChartProps, ...others } =
+        props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -50,7 +51,15 @@ const RadarChart = (props: Props) => {
 
     const newProps = { ...radarChartProps, onClick };
 
-    return <MantineRadarChart radarChartProps={newProps} {...others} />;
+    return (
+        <MantineRadarChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            radarChartProps={newProps}
+            {...others}
+        />
+    );
 };
 
 RadarChart.defaultProps = {};

--- a/src/ts/components/charts/ScatterChart.tsx
+++ b/src/ts/components/charts/ScatterChart.tsx
@@ -39,7 +39,8 @@ interface Props
 
 /** ScatterChart */
 const ScatterChart = (props: Props) => {
-    const { setProps, clickData, scatterProps, ...others } = props;
+    const { setProps, loading_state, clickData, scatterProps, ...others } =
+        props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -49,7 +50,15 @@ const ScatterChart = (props: Props) => {
 
     const newProps = { ...scatterProps, onClick };
 
-    return <MantineScatterChart scatterProps={newProps} {...others} />;
+    return (
+        <MantineScatterChart
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            scatterProps={newProps}
+            {...others}
+        />
+    );
 };
 
 ScatterChart.defaultProps = {};

--- a/src/ts/components/charts/Sparkline.tsx
+++ b/src/ts/components/charts/Sparkline.tsx
@@ -28,9 +28,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Sparkline */
 const Sparkline = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineSparkline {...others} />;
+    return (
+        <MantineSparkline
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Sparkline.defaultProps = {};

--- a/src/ts/components/core/Affix.tsx
+++ b/src/ts/components/core/Affix.tsx
@@ -15,9 +15,18 @@ interface Props
 
 /** Affix */
 const Affix = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineAffix {...others}>{children}</MantineAffix>;
+    return (
+        <MantineAffix
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineAffix>
+    );
 };
 
 Affix.defaultProps = {};

--- a/src/ts/components/core/Alert.tsx
+++ b/src/ts/components/core/Alert.tsx
@@ -33,7 +33,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Alert */
 const Alert = (props: Props) => {
-    const { children, setProps, duration, hide, ...others } = props;
+    const { children, setProps, loading_state, duration, hide, ...others } = props;
     const ref = useRef(null);
 
     useEffect(() => {
@@ -52,7 +52,13 @@ const Alert = (props: Props) => {
     };
 
     return hide ? null : (
-        <MantineAlert {...others} onClose={onClose}>
+        <MantineAlert
+            {...others}
+            onClose={onClose}
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+        >
             {children}
         </MantineAlert>
     );

--- a/src/ts/components/core/Alert.tsx
+++ b/src/ts/components/core/Alert.tsx
@@ -33,7 +33,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Alert */
 const Alert = (props: Props) => {
-    const { children, setProps, loading_state, duration, hide, ...others } = props;
+    const { children, setProps, loading_state, duration, hide, ...others } =
+        props;
     const ref = useRef(null);
 
     useEffect(() => {

--- a/src/ts/components/core/Anchor.tsx
+++ b/src/ts/components/core/Anchor.tsx
@@ -20,12 +20,23 @@ interface Props extends Omit<TextProps, "span">, DashBaseProps {
 
 /** Anchor */
 const Anchor = (props: Props) => {
-    const { href, target, refresh, children, setProps, ...others } = props;
+    const {
+        href,
+        target,
+        refresh,
+        children,
+        setProps,
+        loading_state,
+        ...others
+    } = props;
 
     const sanitizedHref = useMemo(() => sanitizeUrl(href), [href]);
 
     return (
         <MantineAnchor
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                 onClick(ev, sanitizedHref, target, refresh)
             }

--- a/src/ts/components/core/AspectRatio.tsx
+++ b/src/ts/components/core/AspectRatio.tsx
@@ -13,9 +13,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AspectRatio */
 const AspectRatio = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineAspectRatio {...others}>{children}</MantineAspectRatio>;
+    return (
+        <MantineAspectRatio
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineAspectRatio>
+    );
 };
 
 AspectRatio.defaultProps = {};

--- a/src/ts/components/core/Badge.tsx
+++ b/src/ts/components/core/Badge.tsx
@@ -35,9 +35,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Badge */
 const Badge = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineBadge {...others}>{children}</MantineBadge>;
+    return (
+        <MantineBadge
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineBadge>
+    );
 };
 
 Badge.defaultProps = {};

--- a/src/ts/components/core/Blockquote.tsx
+++ b/src/ts/components/core/Blockquote.tsx
@@ -26,9 +26,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Blockquote */
 const Blockquote = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineBlockquote {...others}>{children}</MantineBlockquote>;
+    return (
+        <MantineBlockquote
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineBlockquote>
+    );
 };
 
 Blockquote.defaultProps = {};

--- a/src/ts/components/core/Box.tsx
+++ b/src/ts/components/core/Box.tsx
@@ -10,9 +10,18 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Box */
 const Box = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineBox {...others}>{children}</MantineBox>;
+    return (
+        <MantineBox
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineBox>
+    );
 };
 
 Box.defaultProps = {};

--- a/src/ts/components/core/Breadcrumbs.tsx
+++ b/src/ts/components/core/Breadcrumbs.tsx
@@ -18,9 +18,18 @@ export interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Breadcrumbs */
 const Breadcrumbs = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineBreadcrumbs {...others}>{children}</MantineBreadcrumbs>;
+    return (
+        <MantineBreadcrumbs
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineBreadcrumbs>
+    );
 };
 
 Breadcrumbs.defaultProps = {};

--- a/src/ts/components/core/Burger.tsx
+++ b/src/ts/components/core/Burger.tsx
@@ -29,6 +29,7 @@ interface Props
 const Burger = (props: Props) => {
     const {
         setProps,
+        loading_state,
         opened,
         persistence,
         persisted_props,
@@ -42,7 +43,16 @@ const Burger = (props: Props) => {
         });
     };
 
-    return <MantineBurger onClick={onClick} opened={opened} {...others} />;
+    return (
+        <MantineBurger
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onClick={onClick}
+            opened={opened}
+            {...others}
+        />
+    );
 };
 
 Burger.defaultProps = {

--- a/src/ts/components/core/Center.tsx
+++ b/src/ts/components/core/Center.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Center */
 const Center = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineCenter {...others}>{children}</MantineCenter>;
+    return (
+        <MantineCenter
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineCenter>
+    );
 };
 
 Center.defaultProps = {};

--- a/src/ts/components/core/Code.tsx
+++ b/src/ts/components/core/Code.tsx
@@ -15,9 +15,18 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Code */
 const Code = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineCode {...others}>{children}</MantineCode>;
+    return (
+        <MantineCode
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineCode>
+    );
 };
 
 Code.defaultProps = {};

--- a/src/ts/components/core/Collapse.tsx
+++ b/src/ts/components/core/Collapse.tsx
@@ -18,10 +18,18 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Collapse */
 const Collapse = (props: Props) => {
-    const { setProps, opened, ...others } = props;
-    return <MantineCollapse in={opened} {...others} />;
+    const { setProps, loading_state, opened, ...others } = props;
+    return (
+        <MantineCollapse
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            in={opened}
+            {...others}
+        />
+    );
 };
 
-Collapse.defaultProps = {opened: false};
+Collapse.defaultProps = { opened: false };
 
 export default Collapse;

--- a/src/ts/components/core/Container.tsx
+++ b/src/ts/components/core/Container.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Container */
 const Container = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineContainer {...others}>{children}</MantineContainer>;
+    return (
+        <MantineContainer
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineContainer>
+    );
 };
 
 Container.defaultProps = {};

--- a/src/ts/components/core/Divider.tsx
+++ b/src/ts/components/core/Divider.tsx
@@ -23,9 +23,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Divider */
 const Divider = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineDivider {...others} />;
+    return (
+        <MantineDivider
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Divider.defaultProps = {};

--- a/src/ts/components/core/Divider.tsx
+++ b/src/ts/components/core/Divider.tsx
@@ -27,9 +27,6 @@ const Divider = (props: Props) => {
 
     return (
         <MantineDivider
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         />
     );

--- a/src/ts/components/core/Drawer.tsx
+++ b/src/ts/components/core/Drawer.tsx
@@ -33,7 +33,7 @@ interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
 
 /** Drawer */
 const Drawer = (props: Props) => {
-    const { setProps, opened, children, ...others } = props;
+    const { setProps, loading_state, opened, children, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -46,7 +46,14 @@ const Drawer = (props: Props) => {
     };
 
     return (
-        <MantineDrawer opened={open} onClose={onClose} {...others}>
+        <MantineDrawer
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            opened={open}
+            onClose={onClose}
+            {...others}
+        >
             {children}
         </MantineDrawer>
     );

--- a/src/ts/components/core/Fieldset.tsx
+++ b/src/ts/components/core/Fieldset.tsx
@@ -17,9 +17,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Fieldset */
 const Fieldset = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineFieldset {...others}>{children}</MantineFieldset>;
+    return (
+        <MantineFieldset
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineFieldset>
+    );
 };
 
 Fieldset.defaultProps = {};

--- a/src/ts/components/core/Flex.tsx
+++ b/src/ts/components/core/Flex.tsx
@@ -25,9 +25,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Flex */
 const Flex = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineFlex {...others}>{children}</MantineFlex>;
+    return (
+        <MantineFlex
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineFlex>
+    );
 };
 
 Flex.defaultProps = {};

--- a/src/ts/components/core/Group.tsx
+++ b/src/ts/components/core/Group.tsx
@@ -23,9 +23,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Group */
 const Group = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineGroup {...others}>{children}</MantineGroup>;
+    return (
+        <MantineGroup
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineGroup>
+    );
 };
 
 Group.defaultProps = {};

--- a/src/ts/components/core/Highlight.tsx
+++ b/src/ts/components/core/Highlight.tsx
@@ -16,9 +16,18 @@ interface Props extends DashBaseProps, TextProps {
 
 /** Highlight */
 const Highlight = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineHighlight {...others}>{children}</MantineHighlight>;
+    return (
+        <MantineHighlight
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineHighlight>
+    );
 };
 
 Highlight.defaultProps = {};

--- a/src/ts/components/core/Indicator.tsx
+++ b/src/ts/components/core/Indicator.tsx
@@ -40,9 +40,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Indicator */
 const Indicator = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineIndicator {...others}>{children} </MantineIndicator>;
+    return (
+        <MantineIndicator
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}{" "}
+        </MantineIndicator>
+    );
 };
 
 Indicator.defaultProps = {};

--- a/src/ts/components/core/Kbd.tsx
+++ b/src/ts/components/core/Kbd.tsx
@@ -13,9 +13,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Kbd */
 const Kbd = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
-    return <MantineKbd {...others}>{children}</MantineKbd>;
+    return (
+        <MantineKbd
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineKbd>
+    );
 };
 
 Kbd.defaultProps = {};

--- a/src/ts/components/core/Loader.tsx
+++ b/src/ts/components/core/Loader.tsx
@@ -7,9 +7,16 @@ interface Props extends LoaderProps, DashBaseProps {}
 
 /** Loader */
 const Loader = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineLoader {...others} />;
+    return (
+        <MantineLoader
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Loader.defaultProps = {};

--- a/src/ts/components/core/LoadingOverlay.tsx
+++ b/src/ts/components/core/LoadingOverlay.tsx
@@ -22,9 +22,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** LoadingOverlay */
 const LoadingOverlay = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineLoadingOverlay {...others} />;
+    return (
+        <MantineLoadingOverlay
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 LoadingOverlay.defaultProps = {};

--- a/src/ts/components/core/Mark.tsx
+++ b/src/ts/components/core/Mark.tsx
@@ -13,9 +13,18 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Mark */
 const Mark = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineMark {...others}>{children}</MantineMark>;
+    return (
+        <MantineMark
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineMark>
+    );
 };
 
 Mark.defaultProps = {};

--- a/src/ts/components/core/Modal.tsx
+++ b/src/ts/components/core/Modal.tsx
@@ -8,7 +8,7 @@ interface Props extends ModalProps, StylesApiProps, DashBaseProps {}
 
 /** Modal */
 const Modal = (props: Props) => {
-    const { children, setProps, opened, ...others } = props;
+    const { children, setProps, loading_state, opened, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -21,7 +21,14 @@ const Modal = (props: Props) => {
     };
 
     return (
-        <MantineModal opened={open} onClose={onClose} {...others}>
+        <MantineModal
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            opened={open}
+            onClose={onClose}
+            {...others}
+        >
             {children}
         </MantineModal>
     );

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -63,6 +63,7 @@ const NavLink = (props: Props) => {
         persisted_props,
         persistence_type,
         setProps,
+        loading_state,
         ...others
     } = props;
 
@@ -81,6 +82,9 @@ const NavLink = (props: Props) => {
     if (href) {
         return (
             <MantineNavLink
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
                 component="a"
                 onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                     onClick(ev, href, target, refresh)

--- a/src/ts/components/core/NumberFormatter.tsx
+++ b/src/ts/components/core/NumberFormatter.tsx
@@ -25,9 +25,16 @@ interface Props extends DashBaseProps {
 
 /** NumberFormatter */
 const NumberFormatter = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineNumberFormatter {...others} />;
+    return (
+        <MantineNumberFormatter
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 NumberFormatter.defaultProps = {};

--- a/src/ts/components/core/Overlay.tsx
+++ b/src/ts/components/core/Overlay.tsx
@@ -7,9 +7,16 @@ interface Props extends OverlayProps, DashBaseProps {}
 
 /** Overlay */
 const Overlay = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineOverlay {...others} />;
+    return (
+        <MantineOverlay
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Overlay.defaultProps = {};

--- a/src/ts/components/core/Pagination.tsx
+++ b/src/ts/components/core/Pagination.tsx
@@ -44,6 +44,7 @@ interface Props
 const Pagination = (props: Props) => {
     const {
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -54,7 +55,15 @@ const Pagination = (props: Props) => {
         setProps({ value });
     };
 
-    return <MantinePagination {...others} onChange={onChange} />;
+    return (
+        <MantinePagination
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+            onChange={onChange}
+        />
+    );
 };
 
 Pagination.defaultProps = {

--- a/src/ts/components/core/Pagination.tsx
+++ b/src/ts/components/core/Pagination.tsx
@@ -57,9 +57,6 @@ const Pagination = (props: Props) => {
 
     return (
         <MantinePagination
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
             onChange={onChange}
         />

--- a/src/ts/components/core/Paper.tsx
+++ b/src/ts/components/core/Paper.tsx
@@ -15,9 +15,18 @@ interface Props
 
 /** Paper */
 const Paper = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantinePaper {...others}>{children}</MantinePaper>;
+    return (
+        <MantinePaper
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantinePaper>
+    );
 };
 
 Paper.defaultProps = {};

--- a/src/ts/components/core/Rating.tsx
+++ b/src/ts/components/core/Rating.tsx
@@ -52,9 +52,6 @@ const Rating = (props: Props) => {
 
     return (
         <MantineRating
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             value={val}
             onChange={setVal}
             {...others}

--- a/src/ts/components/core/Rating.tsx
+++ b/src/ts/components/core/Rating.tsx
@@ -38,7 +38,7 @@ interface Props
 
 /** Rating */
 const Rating = (props: Props) => {
-    const { setProps, value, ...others } = props;
+    const { setProps, loading_state, value, ...others } = props;
 
     const [val, setVal] = useState(value);
 
@@ -50,7 +50,16 @@ const Rating = (props: Props) => {
         setVal(value);
     }, [value]);
 
-    return <MantineRating value={val} onChange={setVal} {...others} />;
+    return (
+        <MantineRating
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            value={val}
+            onChange={setVal}
+            {...others}
+        />
+    );
 };
 
 Rating.defaultProps = {

--- a/src/ts/components/core/RingProgress.tsx
+++ b/src/ts/components/core/RingProgress.tsx
@@ -34,9 +34,6 @@ const RingProgress = (props: Props) => {
 
     return (
         <MantineRingProgress
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         />
     );

--- a/src/ts/components/core/RingProgress.tsx
+++ b/src/ts/components/core/RingProgress.tsx
@@ -30,9 +30,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** RingProgress */
 const RingProgress = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineRingProgress {...others} />;
+    return (
+        <MantineRingProgress
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 RingProgress.defaultProps = {};

--- a/src/ts/components/core/ScrollArea.tsx
+++ b/src/ts/components/core/ScrollArea.tsx
@@ -27,9 +27,18 @@ interface Props extends ScrollAreaProps, DashBaseProps {
 
 /** ScrollArea */
 const ScrollArea = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
-    return <MantineScrollArea {...others}>{children}</MantineScrollArea>;
+    return (
+        <MantineScrollArea
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineScrollArea>
+    );
 };
 
 ScrollArea.defaultProps = {};

--- a/src/ts/components/core/SegmentedControl.tsx
+++ b/src/ts/components/core/SegmentedControl.tsx
@@ -51,6 +51,7 @@ const SegmentedControl = (props: Props) => {
     const {
         data,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -76,6 +77,9 @@ const SegmentedControl = (props: Props) => {
 
     return (
         <MantineSegmentedControl
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             data={renderedData}
             onChange={onChange}
             {...others}

--- a/src/ts/components/core/SimpleGrid.tsx
+++ b/src/ts/components/core/SimpleGrid.tsx
@@ -21,9 +21,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** SimpleGrid */
 const SimpleGrid = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineSimpleGrid {...others}>{children}</MantineSimpleGrid>;
+    return (
+        <MantineSimpleGrid
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineSimpleGrid>
+    );
 };
 
 SimpleGrid.defaultProps = {};

--- a/src/ts/components/core/Skeleton.tsx
+++ b/src/ts/components/core/Skeleton.tsx
@@ -1,14 +1,13 @@
 import { Skeleton as MantineSkeleton } from "@mantine/core";
 import { BoxProps } from "props/box";
-import { DashBaseProps, LoadingStateProps } from "props/dash";
+import { DashBaseProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import React from "react";
 
 interface Props
     extends BoxProps,
         StylesApiProps,
-        DashBaseProps,
-        LoadingStateProps {
+        DashBaseProps {
     /** Determines whether Skeleton overlay should be displayed, `true` by default */
     visible?: boolean;
     /** Skeleton `height`, numbers are converted to rem, `auto` by default */

--- a/src/ts/components/core/Skeleton.tsx
+++ b/src/ts/components/core/Skeleton.tsx
@@ -4,10 +4,7 @@ import { DashBaseProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import React from "react";
 
-interface Props
-    extends BoxProps,
-        StylesApiProps,
-        DashBaseProps {
+interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     /** Determines whether Skeleton overlay should be displayed, `true` by default */
     visible?: boolean;
     /** Skeleton `height`, numbers are converted to rem, `auto` by default */

--- a/src/ts/components/core/Space.tsx
+++ b/src/ts/components/core/Space.tsx
@@ -10,9 +10,18 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Space */
 const Space = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineSpace {...others}>{children}</MantineSpace>;
+    return (
+        <MantineSpace
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineSpace>
+    );
 };
 
 Space.defaultProps = {};

--- a/src/ts/components/core/Spoiler.tsx
+++ b/src/ts/components/core/Spoiler.tsx
@@ -24,7 +24,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Spoiler */
 const Spoiler = (props: Props) => {
-    const { setProps, expanded, children, ...others } = props;
+    const { setProps, loading_state, expanded, children, ...others } = props;
 
     const [opened, setOpened] = useState(expanded);
 
@@ -38,6 +38,9 @@ const Spoiler = (props: Props) => {
 
     return (
         <MantineSpoiler
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             expanded={opened}
             onExpandedChange={setOpened}
             {...others}

--- a/src/ts/components/core/Stack.tsx
+++ b/src/ts/components/core/Stack.tsx
@@ -17,9 +17,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Stack */
 const Stack = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineStack {...others}>{children}</MantineStack>;
+    return (
+        <MantineStack
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineStack>
+    );
 };
 
 Stack.defaultProps = {};

--- a/src/ts/components/core/Switch.tsx
+++ b/src/ts/components/core/Switch.tsx
@@ -46,6 +46,7 @@ interface Props
 const Switch = (props: Props) => {
     const {
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -58,6 +59,9 @@ const Switch = (props: Props) => {
 
     return (
         <MantineSwitch
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onChange={(ev) => updateProps(ev.currentTarget.checked)}
             {...others}
         />

--- a/src/ts/components/core/Switch.tsx
+++ b/src/ts/components/core/Switch.tsx
@@ -59,9 +59,6 @@ const Switch = (props: Props) => {
 
     return (
         <MantineSwitch
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             onChange={(ev) => updateProps(ev.currentTarget.checked)}
             {...others}
         />

--- a/src/ts/components/core/Text.tsx
+++ b/src/ts/components/core/Text.tsx
@@ -10,9 +10,18 @@ interface Props extends TextProps, DashBaseProps {
 
 /** Text */
 const Text = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineText {...others}>{children}</MantineText>;
+    return (
+        <MantineText
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineText>
+    );
 };
 
 Text.defaultProps = {};

--- a/src/ts/components/core/ThemeIcon.tsx
+++ b/src/ts/components/core/ThemeIcon.tsx
@@ -27,9 +27,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ThemeIcon */
 const ThemeIcon = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineThemeIcon {...others}>{children}</MantineThemeIcon>;
+    return (
+        <MantineThemeIcon
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineThemeIcon>
+    );
 };
 
 ThemeIcon.defaultProps = {};

--- a/src/ts/components/core/ThemeIcon.tsx
+++ b/src/ts/components/core/ThemeIcon.tsx
@@ -31,9 +31,6 @@ const ThemeIcon = (props: Props) => {
 
     return (
         <MantineThemeIcon
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         >
             {children}

--- a/src/ts/components/core/Title.tsx
+++ b/src/ts/components/core/Title.tsx
@@ -19,9 +19,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** Title */
 const Title = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineTitle {...others}>{children}</MantineTitle>;
+    return (
+        <MantineTitle
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineTitle>
+    );
 };
 
 Title.defaultProps = {};

--- a/src/ts/components/core/VisuallyHidden.tsx
+++ b/src/ts/components/core/VisuallyHidden.tsx
@@ -11,10 +11,17 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** VisuallyHidden */
 const VisuallyHidden = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return (
-        <MantineVisuallyHidden {...others}>{children}</MantineVisuallyHidden>
+        <MantineVisuallyHidden
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineVisuallyHidden>
     );
 };
 

--- a/src/ts/components/core/accordion/Accordion.tsx
+++ b/src/ts/components/core/accordion/Accordion.tsx
@@ -46,6 +46,7 @@ const Accordion = (props: Props) => {
     const {
         children,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -57,7 +58,13 @@ const Accordion = (props: Props) => {
     };
 
     return (
-        <MantineAccordion onChange={onChange} {...others}>
+        <MantineAccordion
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onChange={onChange}
+            {...others}
+        >
             {children}
         </MantineAccordion>
     );

--- a/src/ts/components/core/accordion/AccordionControl.tsx
+++ b/src/ts/components/core/accordion/AccordionControl.tsx
@@ -17,9 +17,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionControl */
 const AccordionControl = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Accordion.Control {...others}>{children}</Accordion.Control>;
+    return (
+        <Accordion.Control
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Accordion.Control>
+    );
 };
 
 AccordionControl.defaultProps = {};

--- a/src/ts/components/core/accordion/AccordionItem.tsx
+++ b/src/ts/components/core/accordion/AccordionItem.tsx
@@ -13,9 +13,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionItem */
 const AccordionItem = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Accordion.Item {...others}>{children}</Accordion.Item>;
+    return (
+        <Accordion.Item
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Accordion.Item>
+    );
 };
 
 AccordionItem.defaultProps = {};

--- a/src/ts/components/core/accordion/AccordionPanel.tsx
+++ b/src/ts/components/core/accordion/AccordionPanel.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionPanel */
 const AccordionPanel = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Accordion.Panel {...others}>{children}</Accordion.Panel>;
+    return (
+        <Accordion.Panel
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Accordion.Panel>
+    );
 };
 
 AccordionPanel.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShell.tsx
+++ b/src/ts/components/core/appshell/AppShell.tsx
@@ -43,9 +43,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShell */
 const AppShell = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineAppShell {...others}>{children}</MantineAppShell>;
+    return (
+        <MantineAppShell
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineAppShell>
+    );
 };
 
 AppShell.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellAside.tsx
+++ b/src/ts/components/core/appshell/AppShellAside.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellAside */
 const AppShellAside = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Aside {...others}>{children}</AppShell.Aside>;
+    return (
+        <AppShell.Aside
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Aside>
+    );
 };
 
 AppShellAside.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellFooter.tsx
+++ b/src/ts/components/core/appshell/AppShellFooter.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellFooter */
 const AppShellFooter = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Footer {...others}>{children}</AppShell.Footer>;
+    return (
+        <AppShell.Footer
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Footer>
+    );
 };
 
 AppShellFooter.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellHeader.tsx
+++ b/src/ts/components/core/appshell/AppShellHeader.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellHeader */
 const AppShellHeader = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Header {...others}>{children}</AppShell.Header>;
+    return (
+        <AppShell.Header
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Header>
+    );
 };
 
 AppShellHeader.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellMain.tsx
+++ b/src/ts/components/core/appshell/AppShellMain.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellMain */
 const AppShellMain = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Main {...others}>{children}</AppShell.Main>;
+    return (
+        <AppShell.Main
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Main>
+    );
 };
 
 AppShellMain.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellNavbar.tsx
+++ b/src/ts/components/core/appshell/AppShellNavbar.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellNavbar */
 const AppShellNavbar = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Navbar {...others}>{children}</AppShell.Navbar>;
+    return (
+        <AppShell.Navbar
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Navbar>
+    );
 };
 
 AppShellNavbar.defaultProps = {};

--- a/src/ts/components/core/appshell/AppShellSection.tsx
+++ b/src/ts/components/core/appshell/AppShellSection.tsx
@@ -13,9 +13,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellSection */
 const AppShellSection = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <AppShell.Section {...others}>{children}</AppShell.Section>;
+    return (
+        <AppShell.Section
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </AppShell.Section>
+    );
 };
 
 AppShellSection.defaultProps = {};

--- a/src/ts/components/core/avatar/Avatar.tsx
+++ b/src/ts/components/core/avatar/Avatar.tsx
@@ -34,11 +34,17 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Avatar */
 const Avatar = (props: Props) => {
-    const { children, src, setProps, ...others } = props;
+    const { children, src, setProps, loading_state, ...others } = props;
     const sanitizedSrc = useMemo(() => sanitizeUrl(src), [src]);
 
     return (
-        <MantineAvatar src={sanitizedSrc} {...others}>
+        <MantineAvatar
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            src={sanitizedSrc}
+            {...others}
+        >
             {children}
         </MantineAvatar>
     );

--- a/src/ts/components/core/avatar/AvatarGroup.tsx
+++ b/src/ts/components/core/avatar/AvatarGroup.tsx
@@ -13,9 +13,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AvatarGroup */
 const AvatarGroup = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Avatar.Group {...others}>{children}</Avatar.Group>;
+    return (
+        <Avatar.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Avatar.Group>
+    );
 };
 
 AvatarGroup.defaultProps = {};

--- a/src/ts/components/core/button/ActionIcon.tsx
+++ b/src/ts/components/core/button/ActionIcon.tsx
@@ -10,7 +10,8 @@ interface Props extends ActionIconProps, DashBaseProps {
 
 /** ActionIcon */
 const ActionIcon = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } = props;
+    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+        props;
 
     const increment = () => {
         if (!disabled) {
@@ -21,7 +22,14 @@ const ActionIcon = (props: Props) => {
     };
 
     return (
-        <MantineActionIcon disabled={disabled} onClick={increment} {...others}>
+        <MantineActionIcon
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            disabled={disabled}
+            onClick={increment}
+            {...others}
+        >
             {children}
         </MantineActionIcon>
     );

--- a/src/ts/components/core/button/ActionIconGroup.tsx
+++ b/src/ts/components/core/button/ActionIconGroup.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ActionIconGroup */
 const ActionIconGroup = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <ActionIcon.Group {...others}>{children}</ActionIcon.Group>;
+    return (
+        <ActionIcon.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </ActionIcon.Group>
+    );
 };
 
 ActionIconGroup.defaultProps = {};

--- a/src/ts/components/core/button/Button.tsx
+++ b/src/ts/components/core/button/Button.tsx
@@ -44,7 +44,8 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Button */
 const Button = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } = props;
+    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+        props;
 
     const increment = () => {
         if (!disabled) {
@@ -55,7 +56,14 @@ const Button = (props: Props) => {
     };
 
     return (
-        <MantineButton onClick={increment} disabled={disabled} {...others}>
+        <MantineButton
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onClick={increment}
+            disabled={disabled}
+            {...others}
+        >
             {children}
         </MantineButton>
     );

--- a/src/ts/components/core/button/ButtonGroup.tsx
+++ b/src/ts/components/core/button/ButtonGroup.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ButtonGroup */
 const ButtonGroup = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Button.Group {...others}>{children}</Button.Group>;
+    return (
+        <Button.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Button.Group>
+    );
 };
 
 ButtonGroup.defaultProps = {};

--- a/src/ts/components/core/button/UnstyledButton.tsx
+++ b/src/ts/components/core/button/UnstyledButton.tsx
@@ -18,7 +18,8 @@ export interface Props
 
 /** UnstyledButton */
 const UnstyledButton = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } = props;
+    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+        props;
 
     const increment = () => {
         if (!disabled) {
@@ -30,6 +31,9 @@ const UnstyledButton = (props: Props) => {
 
     return (
         <MantineUnstyledButton
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onClick={increment}
             disabled={disabled}
             {...others}

--- a/src/ts/components/core/card/Card.tsx
+++ b/src/ts/components/core/card/Card.tsx
@@ -24,9 +24,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Card */
 const Card = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineCard {...others}>{children}</MantineCard>;
+    return (
+        <MantineCard
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineCard>
+    );
 };
 
 Card.defaultProps = {};

--- a/src/ts/components/core/card/CardSection.tsx
+++ b/src/ts/components/core/card/CardSection.tsx
@@ -15,9 +15,18 @@ export interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CardSection */
 const CardSection = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Card.Section {...others}>{children}</Card.Section>;
+    return (
+        <Card.Section
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Card.Section>
+    );
 };
 
 CardSection.defaultProps = {};

--- a/src/ts/components/core/checkbox/Checkbox.tsx
+++ b/src/ts/components/core/checkbox/Checkbox.tsx
@@ -48,6 +48,7 @@ interface Props
 const Checkbox = (props: Props) => {
     const {
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -56,6 +57,9 @@ const Checkbox = (props: Props) => {
 
     return (
         <MantineCheckbox
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onChange={(ev) => setProps({ checked: ev.currentTarget.checked })}
             {...others}
         />

--- a/src/ts/components/core/checkbox/CheckboxGroup.tsx
+++ b/src/ts/components/core/checkbox/CheckboxGroup.tsx
@@ -28,6 +28,7 @@ const CheckboxGroup = (props: Props) => {
     const {
         children,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -39,7 +40,13 @@ const CheckboxGroup = (props: Props) => {
     };
 
     return (
-        <Checkbox.Group onChange={onChange} {...others}>
+        <Checkbox.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onChange={onChange}
+            {...others}
+        >
             {children}
         </Checkbox.Group>
     );

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -56,7 +56,13 @@ const Chip = (props: Props) => {
     };
 
     return (
-        <MantineChip onChange={onChange} {...others}>
+        <MantineChip
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onChange={onChange}
+            {...others}
+        >
             {children}
         </MantineChip>
     );

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -45,6 +45,7 @@ const Chip = (props: Props) => {
     const {
         children,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -45,7 +45,6 @@ const Chip = (props: Props) => {
     const {
         children,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -57,13 +56,7 @@ const Chip = (props: Props) => {
     };
 
     return (
-        <MantineChip
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
-            onChange={onChange}
-            {...others}
-        >
+        <MantineChip onChange={onChange} {...others}>
             {children}
         </MantineChip>
     );

--- a/src/ts/components/core/chip/ChipGroup.tsx
+++ b/src/ts/components/core/chip/ChipGroup.tsx
@@ -15,7 +15,6 @@ const ChipGroup = (props: Props) => {
         children,
         value,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -34,15 +33,7 @@ const ChipGroup = (props: Props) => {
     // }, [value]);
 
     return (
-        <Chip.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
-            multiple
-            value={val}
-            onChange={setVal}
-            {...others}
-        >
+        <Chip.Group multiple value={val} onChange={setVal} {...others}>
             {children}
         </Chip.Group>
     );

--- a/src/ts/components/core/chip/ChipGroup.tsx
+++ b/src/ts/components/core/chip/ChipGroup.tsx
@@ -15,6 +15,7 @@ const ChipGroup = (props: Props) => {
         children,
         value,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -33,7 +34,15 @@ const ChipGroup = (props: Props) => {
     // }, [value]);
 
     return (
-        <Chip.Group multiple value={val} onChange={setVal} {...others}>
+        <Chip.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            multiple
+            value={val}
+            onChange={setVal}
+            {...others}
+        >
             {children}
         </Chip.Group>
     );

--- a/src/ts/components/core/color/ColorInput.tsx
+++ b/src/ts/components/core/color/ColorInput.tsx
@@ -10,6 +10,7 @@ interface Props extends ColorInputProps, PersistenceProps, DashBaseProps {}
 const ColorInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         value,
         persistence,
         persisted_props,
@@ -27,7 +28,16 @@ const ColorInput = (props: Props) => {
         setColor(value);
     }, [value]);
 
-    return <MantineColorInput value={color} onChange={setColor} {...others} />;
+    return (
+        <MantineColorInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            value={color}
+            onChange={setColor}
+            {...others}
+        />
+    );
 };
 
 ColorInput.defaultProps = {

--- a/src/ts/components/core/color/ColorPicker.tsx
+++ b/src/ts/components/core/color/ColorPicker.tsx
@@ -10,6 +10,7 @@ interface Props extends ColorPickerProps, PersistenceProps, DashBaseProps {}
 const ColorPicker = (props: Props) => {
     const {
         setProps,
+        loading_state,
         value,
         persistence,
         persisted_props,
@@ -27,7 +28,16 @@ const ColorPicker = (props: Props) => {
         setColor(value);
     }, [value]);
 
-    return <MantineColorPicker value={color} onChange={setColor} {...others} />;
+    return (
+        <MantineColorPicker
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            value={color}
+            onChange={setColor}
+            {...others}
+        />
+    );
 };
 
 ColorPicker.defaultProps = {

--- a/src/ts/components/core/combobox/Autocomplete.tsx
+++ b/src/ts/components/core/combobox/Autocomplete.tsx
@@ -28,7 +28,7 @@ interface Props
 
 /** Autocomplete */
 const Autocomplete = (props: Props) => {
-    const { setProps, data, value, ...others } = props;
+    const { setProps, loading_state, data, value, ...others } = props;
 
     const [autocomplete, setAutocomplete] = useState(value);
     const [options, setOptions] = useState(data);
@@ -51,6 +51,9 @@ const Autocomplete = (props: Props) => {
 
     return (
         <MantineAutocomplete
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             data={options}
             onChange={setAutocomplete}

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -47,7 +47,8 @@ interface Props
 
 /** MultiSelect */
 const MultiSelect = (props: Props) => {
-    const { setProps, loading_state, data, searchValue, value, ...others } = props;
+    const { setProps, loading_state, data, searchValue, value, ...others } =
+        props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -47,7 +47,7 @@ interface Props
 
 /** MultiSelect */
 const MultiSelect = (props: Props) => {
-    const { setProps, data, searchValue, value, ...others } = props;
+    const { setProps, loading_state, searchValue, value, ...others } = props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
@@ -68,7 +68,7 @@ const MultiSelect = (props: Props) => {
     }, [selected]);
 
     useDidUpdate(() => {
-        setSelected(value ?? [])
+        setSelected(value ?? []);
     }, [value]);
 
     useDidUpdate(() => {
@@ -77,6 +77,9 @@ const MultiSelect = (props: Props) => {
 
     return (
         <MantineMultiSelect
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             data={options}
             onChange={setSelected}

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -47,7 +47,7 @@ interface Props
 
 /** MultiSelect */
 const MultiSelect = (props: Props) => {
-    const { setProps, loading_state, searchValue, value, ...others } = props;
+    const { setProps, loading_state, data, searchValue, value, ...others } = props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);

--- a/src/ts/components/core/combobox/Select.tsx
+++ b/src/ts/components/core/combobox/Select.tsx
@@ -43,7 +43,8 @@ interface Props
 
 /** Select */
 const Select = (props: Props) => {
-    const { setProps, data, searchValue, value, ...others } = props;
+    const { setProps, loading_state, data, searchValue, value, ...others } =
+        props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
@@ -73,6 +74,9 @@ const Select = (props: Props) => {
 
     return (
         <MantineSelect
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             data={options}
             onChange={setSelected}

--- a/src/ts/components/core/combobox/TagsInput.tsx
+++ b/src/ts/components/core/combobox/TagsInput.tsx
@@ -46,7 +46,8 @@ interface Props
 
 /** TagsInput */
 const TagsInput = (props: Props) => {
-    const { setProps, data, searchValue, value, ...others } = props;
+    const { setProps, loading_state, data, searchValue, value, ...others } =
+        props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
@@ -76,6 +77,9 @@ const TagsInput = (props: Props) => {
 
     return (
         <MantineTagsInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             data={options}
             onChange={setSelected}

--- a/src/ts/components/core/grid/Grid.tsx
+++ b/src/ts/components/core/grid/Grid.tsx
@@ -23,9 +23,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Grid */
 const Grid = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineGrid {...others}>{children}</MantineGrid>;
+    return (
+        <MantineGrid
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineGrid>
+    );
 };
 
 Grid.defaultProps = {};

--- a/src/ts/components/core/grid/GridCol.tsx
+++ b/src/ts/components/core/grid/GridCol.tsx
@@ -18,9 +18,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** GridCol */
 const GridCol = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Grid.Col {...others}>{children}</Grid.Col>;
+    return (
+        <Grid.Col
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Grid.Col>
+    );
 };
 
 GridCol.defaultProps = {};

--- a/src/ts/components/core/hovercard/HoverCard.tsx
+++ b/src/ts/components/core/hovercard/HoverCard.tsx
@@ -12,10 +12,15 @@ interface Props extends Omit<PopoverProps, "opened">, DashBaseProps {
 
 /** HoverCard */
 const HoverCard = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return (
-        <MantineHoverCard {...others}>
+        <MantineHoverCard
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             {React.Children.map(children, (child: any, index) => {
                 const childType = child.props._dashprivate_layout.type;
                 if (childType === "HoverCardTarget") {

--- a/src/ts/components/core/hovercard/HoverCardDropdown.tsx
+++ b/src/ts/components/core/hovercard/HoverCardDropdown.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** HoverCardDropdown */
 const HoverCardDropdown = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <HoverCard.Dropdown {...others}>{children}</HoverCard.Dropdown>;
+    return (
+        <HoverCard.Dropdown
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </HoverCard.Dropdown>
+    );
 };
 
 HoverCardDropdown.defaultProps = {};

--- a/src/ts/components/core/image/BackgroundImage.tsx
+++ b/src/ts/components/core/image/BackgroundImage.tsx
@@ -18,10 +18,17 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** BackgroundImage  */
 const BackgroundImage = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
     return (
-        <MantineBackgroundImage {...others}>{children}</MantineBackgroundImage>
+        <MantineBackgroundImage
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineBackgroundImage>
     );
 };
 

--- a/src/ts/components/core/image/Image.tsx
+++ b/src/ts/components/core/image/Image.tsx
@@ -19,9 +19,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Image  */
 const Image = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineImage {...others} />;
+    return (
+        <MantineImage
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Image.defaultProps = {};

--- a/src/ts/components/core/input/JsonInput.tsx
+++ b/src/ts/components/core/input/JsonInput.tsx
@@ -19,7 +19,8 @@ interface Props extends TextareaProps, DashBaseProps, PersistenceProps {
 
 /** JsonInput */
 const JsonInput = (props: Props) => {
-    const { setProps, value, n_submit, debounce, ...others } = props;
+    const { setProps, loading_state, value, n_submit, debounce, ...others } =
+        props;
 
     const [val, setVal] = useState(value);
     const [debounced] = useDebouncedValue(val, debounce);
@@ -40,6 +41,9 @@ const JsonInput = (props: Props) => {
 
     return (
         <MantineJsonInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onChange={setVal}
             value={val}

--- a/src/ts/components/core/input/NumberInput.tsx
+++ b/src/ts/components/core/input/NumberInput.tsx
@@ -64,7 +64,8 @@ interface Props
 
 /** NumberInput */
 const NumberInput = (props: Props) => {
-    const { setProps, value, n_submit, debounce, ...others } = props;
+    const { setProps, loading_state, value, n_submit, debounce, ...others } =
+        props;
 
     const [val, setVal] = useState(value);
     const [debounced] = useDebouncedValue(val, debounce);
@@ -85,6 +86,9 @@ const NumberInput = (props: Props) => {
 
     return (
         <MantineNumberInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onChange={setVal}
             value={val}

--- a/src/ts/components/core/input/PasswordInput.tsx
+++ b/src/ts/components/core/input/PasswordInput.tsx
@@ -26,7 +26,8 @@ interface Props
 
 /** PasswordInput */
 const PasswordInput = (props: Props) => {
-    const { setProps, value, n_submit, debounce, ...others } = props;
+    const { setProps, loading_state, value, n_submit, debounce, ...others } =
+        props;
 
     const [val, setVal] = useState(value);
     const [debounced] = useDebouncedValue(val, debounce);
@@ -47,6 +48,9 @@ const PasswordInput = (props: Props) => {
 
     return (
         <MantinePasswordInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}

--- a/src/ts/components/core/input/PinInput.tsx
+++ b/src/ts/components/core/input/PinInput.tsx
@@ -67,10 +67,13 @@ interface Props
 
 /** PinInput */
 const PinInput = (props: Props) => {
-    const { setProps, value, ...others } = props;
+    const { setProps, loading_state, value, ...others } = props;
 
     return (
         <MantinePinInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onComplete={(value) => setProps({ value })}
             {...others}
         />

--- a/src/ts/components/core/input/TextInput.tsx
+++ b/src/ts/components/core/input/TextInput.tsx
@@ -24,6 +24,7 @@ interface Props
 const TextInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         value,
         debounce,
         persistence,
@@ -45,6 +46,9 @@ const TextInput = (props: Props) => {
 
     return (
         <MantineTextInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             {...others}
             value={val}
             wrapperProps={{ autoComplete: "off" }}

--- a/src/ts/components/core/input/Textarea.tsx
+++ b/src/ts/components/core/input/Textarea.tsx
@@ -17,6 +17,7 @@ interface Props extends TextareaProps, DashBaseProps, PersistenceProps {
 const Textarea = (props: Props) => {
     const {
         setProps,
+        loading_state,
         value,
         debounce,
         persistence,
@@ -38,6 +39,9 @@ const Textarea = (props: Props) => {
 
     return (
         <MantineTextarea
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             {...others}
             value={val}
             wrapperProps={{ autoComplete: "off" }}

--- a/src/ts/components/core/list/List.tsx
+++ b/src/ts/components/core/list/List.tsx
@@ -29,9 +29,18 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** List */
 const List = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
-    return <MantineList {...others}>{children}</MantineList>;
+    return (
+        <MantineList
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineList>
+    );
 };
 
 List.defaultProps = {};

--- a/src/ts/components/core/list/ListItem.tsx
+++ b/src/ts/components/core/list/ListItem.tsx
@@ -13,9 +13,18 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** ListItem */
 const ListItem = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
-    return <List.Item {...others}>{children}</List.Item>;
+    return (
+        <List.Item
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </List.Item>
+    );
 };
 
 ListItem.defaultProps = {};

--- a/src/ts/components/core/menu/Menu.tsx
+++ b/src/ts/components/core/menu/Menu.tsx
@@ -39,17 +39,25 @@ interface Props extends __PopoverProps, StylesApiProps {
 
 /** Menu */
 const Menu = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return (
-        <MantineMenu {...others}>
+        <MantineMenu
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             {React.Children.map(children, (child: any, index) => {
-                const {type: childType, props: childProps} = child.props._dashprivate_layout;
+                const { type: childType, props: childProps } =
+                    child.props._dashprivate_layout;
                 if (childType === "MenuTarget") {
                     const { boxWrapperProps } = childProps;
                     return (
                         <MantineMenu.Target key={index}>
-                            <Box w="fit-content" {...boxWrapperProps}>{child}</Box>
+                            <Box w="fit-content" {...boxWrapperProps}>
+                                {child}
+                            </Box>
                         </MantineMenu.Target>
                     );
                 }

--- a/src/ts/components/core/menu/Menu.tsx
+++ b/src/ts/components/core/menu/Menu.tsx
@@ -42,9 +42,7 @@ const Menu = (props: Props) => {
     const { children, setProps, ...others } = props;
 
     return (
-        <MantineMenu
-            {...others}
-        >
+        <MantineMenu {...others}>
             {React.Children.map(children, (child: any, index) => {
                 const { type: childType, props: childProps } =
                     child.props._dashprivate_layout;

--- a/src/ts/components/core/menu/Menu.tsx
+++ b/src/ts/components/core/menu/Menu.tsx
@@ -39,13 +39,10 @@ interface Props extends __PopoverProps, StylesApiProps {
 
 /** Menu */
 const Menu = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
 
     return (
         <MantineMenu
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {

--- a/src/ts/components/core/menu/MenuDivider.tsx
+++ b/src/ts/components/core/menu/MenuDivider.tsx
@@ -8,9 +8,16 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {}
 
 /** MenuDivider */
 const MenuDivider = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <Menu.Divider {...others} />;
+    return (
+        <Menu.Divider
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 MenuDivider.defaultProps = {};

--- a/src/ts/components/core/menu/MenuDropdown.tsx
+++ b/src/ts/components/core/menu/MenuDropdown.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** MenuDropdown */
 const MenuDropdown = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Menu.Dropdown {...others}>{children}</Menu.Dropdown>;
+    return (
+        <Menu.Dropdown
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Menu.Dropdown>
+    );
 };
 
 MenuDropdown.defaultProps = {};

--- a/src/ts/components/core/menu/MenuItem.tsx
+++ b/src/ts/components/core/menu/MenuItem.tsx
@@ -38,6 +38,7 @@ const MenuItem = (props: Props) => {
         refresh,
         n_clicks,
         setProps,
+        loading_state,
         ...others
     } = props;
 
@@ -52,6 +53,9 @@ const MenuItem = (props: Props) => {
     if (href) {
         return (
             <Menu.Item
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
                 component="a"
                 onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                     onClick(ev, href, target, refresh)
@@ -66,7 +70,14 @@ const MenuItem = (props: Props) => {
         );
     } else {
         return (
-            <Menu.Item onClick={increment} disabled={disabled} {...others}>
+            <Menu.Item
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
+                onClick={increment}
+                disabled={disabled}
+                {...others}
+            >
                 {children}
             </Menu.Item>
         );

--- a/src/ts/components/core/menu/MenuLabel.tsx
+++ b/src/ts/components/core/menu/MenuLabel.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** MenuLabel */
 const MenuLabel = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Menu.Label {...others}>{children}</Menu.Label>;
+    return (
+        <Menu.Label
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Menu.Label>
+    );
 };
 
 MenuLabel.defaultProps = {};

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -7,10 +7,15 @@ interface Props extends PopoverProps, DashBaseProps {}
 
 /** Popover */
 const Popover = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return (
-        <MantinePopover {...others}>
+        <MantinePopover
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             {React.Children.map(children, (child: any, index) => {
                 const childType = child.props._dashprivate_layout.type;
                 if (childType === "PopoverTarget") {

--- a/src/ts/components/core/popover/PopoverDropdown.tsx
+++ b/src/ts/components/core/popover/PopoverDropdown.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** PopoverDropdown */
 const PopoverDropdown = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Popover.Dropdown {...others}>{children}</Popover.Dropdown>;
+    return (
+        <Popover.Dropdown
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Popover.Dropdown>
+    );
 };
 
 PopoverDropdown.defaultProps = {};

--- a/src/ts/components/core/progress/Progress.tsx
+++ b/src/ts/components/core/progress/Progress.tsx
@@ -20,9 +20,16 @@ export interface Props
 
 /** Progress */
 const Progress = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineProgress {...others} />;
+    return (
+        <MantineProgress
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 Progress.defaultProps = {};

--- a/src/ts/components/core/progress/ProgressLabel.tsx
+++ b/src/ts/components/core/progress/ProgressLabel.tsx
@@ -11,9 +11,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** ProgressLabel */
 const ProgressLabel = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <Progress.Label {...others} />;
+    return (
+        <Progress.Label
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 ProgressLabel.defaultProps = {};

--- a/src/ts/components/core/progress/ProgressRoot.tsx
+++ b/src/ts/components/core/progress/ProgressRoot.tsx
@@ -7,9 +7,16 @@ export interface Props extends ProgressRootProps, DashBaseProps {}
 
 /** ProgressRoot */
 const ProgressRoot = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <Progress.Root {...others} />;
+    return (
+        <Progress.Root
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 ProgressRoot.defaultProps = {};

--- a/src/ts/components/core/progress/ProgressSection.tsx
+++ b/src/ts/components/core/progress/ProgressSection.tsx
@@ -21,9 +21,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** ProgressSection */
 const ProgressSection = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <Progress.Section {...others} />;
+    return (
+        <Progress.Section
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 ProgressSection.defaultProps = {};

--- a/src/ts/components/core/radio/Radio.tsx
+++ b/src/ts/components/core/radio/Radio.tsx
@@ -42,6 +42,7 @@ interface Props
 const Radio = (props: Props) => {
     const {
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -50,6 +51,9 @@ const Radio = (props: Props) => {
 
     return (
         <MantineRadio
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onChange={(ev) => setProps({ checked: ev.currentTarget.checked })}
             {...others}
         />

--- a/src/ts/components/core/radio/RadioGroup.tsx
+++ b/src/ts/components/core/radio/RadioGroup.tsx
@@ -24,6 +24,7 @@ const RadioGroup = (props: Props) => {
         children,
         value,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -35,7 +36,14 @@ const RadioGroup = (props: Props) => {
     };
 
     return (
-        <Radio.Group onChange={onChange} value={value} {...others}>
+        <Radio.Group
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onChange={onChange}
+            value={value}
+            {...others}
+        >
             {children}
         </Radio.Group>
     );

--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -71,6 +71,7 @@ interface Props
 const RangeSlider = (props: Props) => {
     const {
         setProps,
+        loading_state,
         updatemode,
         value,
         persistence,
@@ -93,6 +94,9 @@ const RangeSlider = (props: Props) => {
 
     return (
         <MantineRangeSlider
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             {...others}
             value={val}
             onChange={setVal}

--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -65,6 +65,7 @@ interface Props
 const Slider = (props: Props) => {
     const {
         setProps,
+        loading_state,
         updatemode,
         value,
         persistence,
@@ -87,6 +88,9 @@ const Slider = (props: Props) => {
 
     return (
         <MantineSlider
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             {...others}
             value={val}
             onChange={setVal}

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -48,7 +48,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** Stepper */
 const Stepper = (props: Props) => {
-    const { setProps, active, children, ...others } = props;
+    const { setProps, loading_state, active, children, ...others } = props;
 
     const [act, setAct] = useState(active);
 
@@ -57,7 +57,13 @@ const Stepper = (props: Props) => {
     }, [active]);
 
     return (
-        <MantineStepper active={act} {...others}>
+        <MantineStepper
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            active={act}
+            {...others}
+        >
             {React.Children.map(children, (child: any, index) => {
                 const childType = child.props._dashprivate_layout.type;
                 if (childType === "StepperCompleted") {

--- a/src/ts/components/core/stepper/StepperStep.tsx
+++ b/src/ts/components/core/stepper/StepperStep.tsx
@@ -41,7 +41,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** StepperStep */
 const StepperStep = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return <>{children}</>;
 };

--- a/src/ts/components/core/table/Table.tsx
+++ b/src/ts/components/core/table/Table.tsx
@@ -46,9 +46,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Table */
 const Table = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
-    return <MantineTable {...others}>{children}</MantineTable>;
+    return (
+        <MantineTable
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineTable>
+    );
 };
 
 Table.defaultProps = {};

--- a/src/ts/components/core/tabs/Tabs.tsx
+++ b/src/ts/components/core/tabs/Tabs.tsx
@@ -46,6 +46,7 @@ const Tabs = (props: Props) => {
     const {
         children,
         setProps,
+        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -57,7 +58,13 @@ const Tabs = (props: Props) => {
     };
 
     return (
-        <MantineTabs onChange={onChange} {...others}>
+        <MantineTabs
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            onChange={onChange}
+            {...others}
+        >
             {children}
         </MantineTabs>
     );

--- a/src/ts/components/core/tabs/TabsList.tsx
+++ b/src/ts/components/core/tabs/TabsList.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** TabsList */
 const TabsList = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Tabs.List {...others}>{children}</Tabs.List>;
+    return (
+        <Tabs.List
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Tabs.List>
+    );
 };
 
 TabsList.defaultProps = {};

--- a/src/ts/components/core/tabs/TabsPanel.tsx
+++ b/src/ts/components/core/tabs/TabsPanel.tsx
@@ -15,9 +15,18 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** TabsPanel */
 const TabsPanel = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Tabs.Panel {...others}>{children}</Tabs.Panel>;
+    return (
+        <Tabs.Panel
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Tabs.Panel>
+    );
 };
 
 TabsPanel.defaultProps = {};

--- a/src/ts/components/core/tabs/TabsTab.tsx
+++ b/src/ts/components/core/tabs/TabsTab.tsx
@@ -25,9 +25,18 @@ interface Props
 
 /** TabsTab */
 const TabsTab = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Tabs.Tab {...others}>{children}</Tabs.Tab>;
+    return (
+        <Tabs.Tab
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </Tabs.Tab>
+    );
 };
 
 TabsTab.defaultProps = {};

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -33,10 +33,15 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Timeline */
 const Timeline = (props: Props) => {
-    const { setProps, children, ...others } = props;
+    const { setProps, loading_state, children, ...others } = props;
 
     return (
-        <MantineTimeline {...others}>
+        <MantineTimeline
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             {React.Children.map(children, (child: any, index) => {
                 const childProps = child.props._dashprivate_layout.props;
                 const renderedProps = renderDashComponents(

--- a/src/ts/components/core/timeline/TimelineItem.tsx
+++ b/src/ts/components/core/timeline/TimelineItem.tsx
@@ -19,7 +19,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** TimelineItem */
 const TimelineItem = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
     return <>{children}</>;
 };

--- a/src/ts/components/core/tooltip/FloatingTooltip.tsx
+++ b/src/ts/components/core/tooltip/FloatingTooltip.tsx
@@ -13,11 +13,17 @@ interface Props extends TooltipBaseProps, DashBaseProps {
 
 /** FloatingTooltip */
 const FloatingTooltip = (props: Props) => {
-    const { children, boxWrapperProps, setProps, ...others } = props;
+    const { children, boxWrapperProps, setProps, loading_state, ...others } =
+        props;
     const boxProps = { w: "fit-content", ...boxWrapperProps };
 
     return (
-        <Tooltip.Floating {...others}>
+        <Tooltip.Floating
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             <Box {...boxProps}>{children}</Box>
         </Tooltip.Floating>
     );

--- a/src/ts/components/core/tooltip/Tooltip.tsx
+++ b/src/ts/components/core/tooltip/Tooltip.tsx
@@ -52,11 +52,17 @@ interface Props extends TooltipBaseProps, DashBaseProps {
 
 /** Tooltip */
 const Tooltip = (props: Props) => {
-    const { children, boxWrapperProps, setProps, ...others } = props;
+    const { children, boxWrapperProps, setProps, loading_state, ...others } =
+        props;
     const boxProps = { w: "fit-content", ...boxWrapperProps };
 
     return (
-        <MantineTooltip {...others}>
+        <MantineTooltip
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
             <Box {...boxProps}>{children}</Box>
         </MantineTooltip>
     );

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -14,7 +14,7 @@ import { StylesApiProps } from "props/styles";
 import React, { useState } from "react";
 import { dateToString, isDisabled, stringToDate } from "../../utils/dates";
 import dayjs from "dayjs";
-import customParseFormat from 'dayjs/plugin/customParseFormat';
+import customParseFormat from "dayjs/plugin/customParseFormat";
 dayjs.extend(customParseFormat);
 
 interface Props
@@ -59,6 +59,7 @@ interface Props
 const DateInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         n_submit,
         value,
         debounce,
@@ -94,6 +95,9 @@ const DateInput = (props: Props) => {
 
     return (
         <MantineDateInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/dates/DatePicker.tsx
+++ b/src/ts/components/dates/DatePicker.tsx
@@ -33,6 +33,7 @@ interface Props
 const DatePicker = (props: Props) => {
     const {
         setProps,
+        loading_state,
         n_submit,
         value,
         debounce,
@@ -68,6 +69,9 @@ const DatePicker = (props: Props) => {
 
     return (
         <DatePickerInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/dates/DateTimePicker.tsx
+++ b/src/ts/components/dates/DateTimePicker.tsx
@@ -46,6 +46,7 @@ interface Props
 const DateTimePicker = (props: Props) => {
     const {
         setProps,
+        loading_state,
         value,
         debounce,
         n_submit,
@@ -81,6 +82,9 @@ const DateTimePicker = (props: Props) => {
 
     return (
         <MantineDateTimePicker
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             onChange={setDate}
             value={date}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/dates/DatesProvider.tsx
+++ b/src/ts/components/dates/DatesProvider.tsx
@@ -4,9 +4,9 @@ import {
 } from "@mantine/dates";
 import dayjs from "dayjs";
 import React, { useEffect } from "react";
-import customParseFormat from 'dayjs/plugin/customParseFormat';
+import customParseFormat from "dayjs/plugin/customParseFormat";
 
-const REGISTERED = {}
+const REGISTERED = {};
 
 interface Props extends DatesProviderProps {
     /** Unique ID to identify this component in Dash callbacks. */

--- a/src/ts/components/dates/MonthPickerInput.tsx
+++ b/src/ts/components/dates/MonthPickerInput.tsx
@@ -1,4 +1,4 @@
-import { MonthPickerInput as MantineMonthPickerInput} from "@mantine/dates";
+import { MonthPickerInput as MantineMonthPickerInput } from "@mantine/dates";
 import { useDebouncedValue, useDidUpdate } from "@mantine/hooks";
 import { BoxProps } from "props/box";
 import { DashBaseProps, PersistenceProps } from "props/dash";
@@ -33,6 +33,7 @@ interface Props
 const MonthPickerInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         n_submit,
         value,
         type,
@@ -69,6 +70,9 @@ const MonthPickerInput = (props: Props) => {
 
     return (
         <MantineMonthPickerInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/dates/TimeInput.tsx
+++ b/src/ts/components/dates/TimeInput.tsx
@@ -26,6 +26,7 @@ interface Props
 const TimeInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         n_submit,
         value,
         debounce,
@@ -54,6 +55,9 @@ const TimeInput = (props: Props) => {
 
     return (
         <MantineTimeInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={(ev) => setTime(ev.currentTarget.value)}

--- a/src/ts/components/dates/YearPickerInput.tsx
+++ b/src/ts/components/dates/YearPickerInput.tsx
@@ -1,4 +1,4 @@
-import { YearPickerInput  as MantineYearPickerInput } from "@mantine/dates";
+import { YearPickerInput as MantineYearPickerInput } from "@mantine/dates";
 import { useDebouncedValue, useDidUpdate } from "@mantine/hooks";
 import { BoxProps } from "props/box";
 import { DashBaseProps, PersistenceProps } from "props/dash";
@@ -33,6 +33,7 @@ interface Props
 const YearPickerInput = (props: Props) => {
     const {
         setProps,
+        loading_state,
         n_submit,
         value,
         type,
@@ -69,6 +70,9 @@ const YearPickerInput = (props: Props) => {
 
     return (
         <MantineYearPickerInput
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/extensions/carousel/Carousel.tsx
+++ b/src/ts/components/extensions/carousel/Carousel.tsx
@@ -59,16 +59,26 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Carousel */
 const Carousel = (props: Props) => {
-  const { children, setProps, autoplay, ...others } = props;
+    const { children, setProps, loading_state, autoplay, ...others } = props;
 
-  const autoplayPlugin =
-    autoplay === true
-      ? Autoplay()
-      : autoplay && typeof autoplay === "object"
-      ? Autoplay(autoplay)  
-      : null;
+    const autoplayPlugin =
+        autoplay === true
+            ? Autoplay()
+            : autoplay && typeof autoplay === "object"
+              ? Autoplay(autoplay)
+              : null;
 
-  return <MantineCarousel {...others} plugins={autoplayPlugin ? [autoplayPlugin] : []}>{children}</MantineCarousel>;
+    return (
+        <MantineCarousel
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+            plugins={autoplayPlugin ? [autoplayPlugin] : []}
+        >
+            {children}
+        </MantineCarousel>
+    );
 };
 
 Carousel.defaultProps = {};

--- a/src/ts/components/extensions/carousel/Carousel.tsx
+++ b/src/ts/components/extensions/carousel/Carousel.tsx
@@ -56,9 +56,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Carousel */
 const Carousel = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <MantineCarousel {...others}>{children} </MantineCarousel>;
+    return (
+        <MantineCarousel
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}{" "}
+        </MantineCarousel>
+    );
 };
 
 Carousel.defaultProps = {};

--- a/src/ts/components/extensions/carousel/CarouselSlide.tsx
+++ b/src/ts/components/extensions/carousel/CarouselSlide.tsx
@@ -11,9 +11,18 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CarouselSlide */
 const CarouselSlide = (props: Props) => {
-    const { children, setProps, ...others } = props;
+    const { children, setProps, loading_state, ...others } = props;
 
-    return <Carousel.Slide {...others}>{children} </Carousel.Slide>;
+    return (
+        <Carousel.Slide
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}{" "}
+        </Carousel.Slide>
+    );
 };
 
 CarouselSlide.defaultProps = {};

--- a/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
@@ -21,9 +21,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CodeHighlight */
 const CodeHighlight = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <MantineCodeHighlight {...others} />;
+    return (
+        <MantineCodeHighlight
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 CodeHighlight.defaultProps = {};

--- a/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
@@ -36,7 +36,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CodeHighlightTabs */
 const CodeHighlightTabs = (props: Props) => {
-    const { setProps, code, ...others } = props;
+    const { setProps, loading_state, code, ...others } = props;
     const renderedCode = [];
     if (Array.isArray(code)) {
         code.forEach((item, index) => {
@@ -46,7 +46,15 @@ const CodeHighlightTabs = (props: Props) => {
         renderedCode.push(renderDashComponents(code, ["icon"]));
     }
 
-    return <MantineCodeHighlightTabs code={renderedCode} {...others} />;
+    return (
+        <MantineCodeHighlightTabs
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            code={renderedCode}
+            {...others}
+        />
+    );
 };
 
 CodeHighlightTabs.defaultProps = {};

--- a/src/ts/components/extensions/notifications/Notification.tsx
+++ b/src/ts/components/extensions/notifications/Notification.tsx
@@ -36,7 +36,7 @@ interface Props extends BoxProps, StylesApiProps, Omit<DashBaseProps, "id"> {
 
 /** Notification */
 const Notification = (props: Props) => {
-    const { action, setProps, ...others } = props;
+    const { action, setProps, loading_state, ...others } = props;
 
     useEffect(() => {
         switch (action) {

--- a/src/ts/components/extensions/notifications/NotificationProvider.tsx
+++ b/src/ts/components/extensions/notifications/NotificationProvider.tsx
@@ -31,9 +31,16 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** NotificationProvider */
 const NotificationProvider = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
-    return <Notifications {...others} />;
+    return (
+        <Notifications
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        />
+    );
 };
 
 NotificationProvider.defaultProps = {};

--- a/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
+++ b/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
@@ -20,7 +20,7 @@ interface Props extends DashBaseProps {
 
 /** NavigationProgressProvider */
 const NavigationProgressProvider = (props: Props) => {
-    const { setProps, ...others } = props;
+    const { setProps, loading_state, ...others } = props;
 
     return <NavigationProgress {...others} />;
 };

--- a/src/ts/props/dash.ts
+++ b/src/ts/props/dash.ts
@@ -9,6 +9,14 @@ export interface DashBaseProps {
     "aria-*"?: string;
     /** tab-index */
     tabIndex?: number;
+    loading_state?: {
+        /** Determines if the component is loading or not */
+        is_loading: boolean;
+        /** Holds which property is loading */
+        prop_name: string;
+        /** Holds the name of the component that is loading */
+        component_name: string;
+    };
 }
 
 export interface PersistenceProps {
@@ -34,16 +42,4 @@ export interface PersistenceProps {
      * session: window.sessionStorage, data is cleared once the browser quit.
      */
     persistence_type?: "local" | "session" | "memory";
-}
-
-export interface LoadingStateProps {
-    /** Object that holds the loading state object coming from dash-renderer */
-    loading_state?: {
-        /** Determines if the component is loading or not */
-        is_loading: boolean;
-        /** Holds which property is loading */
-        prop_name: string;
-        /** Holds the name of the component that is loading */
-        component_name: string;
-    };
 }


### PR DESCRIPTION
Currently the `loading_state` is included in the dom for every dmc component. For example

![image](https://github.com/user-attachments/assets/7e7e0aeb-718e-418f-98a3-26a15bde41e2)


This PR makes it so the `loading_state` is used as intended and is consistent with all other component libraries such as html, dcc and dbc by setting:

```
           data-dash-is-loading={
                (loading_state && loading_state.is_loading) || undefined
            }

```

As a sample I just updated the `dbc.Alert`.  If you run the basic sample app you will see the `loading_state="[object Object]"` is no longer included.

```python
import dash_mantine_components as dmc
from dash import Dash, _dash_renderer
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

app.layout = dmc.MantineProvider(
    dmc.Alert(
       "Hi from Dash Mantine Components. You can create some great looking dashboards using me!",
       title="Welcome!",
       color="violet",
    )
)

if __name__ == "__main__":
    app.run(debug=True)

```

Hey @alexcjohnson - can you give this a quick look and a "pre-approval" before I go ahead make this same change to like 100 components?







