### PR TITLE
minify metadata.py to reduce package size

### DIFF
--- a/.github/releasing.md
+++ b/.github/releasing.md
@@ -18,9 +18,9 @@ On the Master branch:
 $ rm -rf dist
 ```
 
-2. Build source distribution
+2. Build source distribution.  Note this will also minify the metadata.json file which reduces the package size
 ```
- $ python3 -m build --sdist --wheel
+npm run dist
 
 ```
 3. Test your tarball by copying it into a new environment and installing it locally, for example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### Added
 
-
 - Added `autoplay` prop to the `Carousel` component #316 by @mmarfat 
 - Added the `ChipGroup` component and updated `Chip` to work with it. #327 by @AnnMarieW and @BSd3v
-Note: `Chip` was available before but not documented. If you used `Chip` in dmc>=0.14.0 to dmc<=0.14.5, you’ll now need to add `controlled=True` for it to work properly on its own.
+Note: `Chip` was available before but not documented. If you used `Chip` in dmc<=0.14.5, you’ll now need to add `controlled=True` for it to work properly on its own.
 - Added GitHub actions workflow for automated tests on PRs by @BSd3v
 
 
@@ -16,6 +15,9 @@ Note: `Chip` was available before but not documented. If you used `Chip` in dmc>
 - Excluded the `loading_state` prop from being passed to the DOM.   Added `data-dash-is-loading` attribute to
 components during callback execution, allowing custom CSS styling for loading states. #325 by @AnnMarieW
 
+### Changed
+
+- Reduced the package size by minifying the metadata.json file #345 by @AnnMarieW
 
 # 0.14.5 
 

--- a/minify_metadata.py
+++ b/minify_metadata.py
@@ -1,0 +1,16 @@
+"""
+This script makes the metadata.json file smaller in order to reduce the package size
+"""
+
+import json
+
+file_path = 'dash_mantine_components/metadata.json'
+
+with open(file_path, 'r') as file:
+    data = json.load(file)
+
+# Write the compact version (no spaces or line breaks) back to the file
+with open(file_path, 'w') as file:
+    json.dump(data, file, separators=(',', ':'))
+
+print("JSON file has been compacted.")

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build:backends": "dash-generate-components ./src/ts/components dash_mantine_components -p package-info.json --r-prefix '' --jl-prefix '' --ignore \\.test\\.",
         "build": "npm run build:js && npm run build:backends",
         "watch": "npm run build:js::dev -- --watch",
-        "dist": "python setup.py sdist bdist_wheel"
+        "dist": "python minify_metadata.py && python setup.py sdist bdist_wheel"
     },
     "devDependencies": {
         "@braintree/sanitize-url": "^7.0.0",


### PR DESCRIPTION
closes #271 

This PR reduces the size of the metadata.json from 5.5MB to 3.0MB :tada: 

- adds a new script `minify_metadata.py` to reduce the file size
- updates the `dist` script to run  `minify_metadata.py` before creating the source distribution 
- updates the `release.md` file so I remember how do to this when making a release :stuck_out_tongue:  

