### PR TITLE
add missing chart props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added `autoplay` prop to the `Carousel` component #316 by @mmarfat 
 - Added the `ChipGroup` component and updated `Chip` to work with it. #327 by @AnnMarieW and @BSd3v
 Note: `Chip` was available before but not documented. If you used `Chip` in dmc<=0.14.5, you’ll now need to add `controlled=True` for it to work properly on its own.
-- Added GitHub actions workflow for automated tests on PRs by @BSd3v
+- Added GitHub actions workflow for automated tests on PRs #333 by @BSd3v
+- Added new and missing props to the charts #349 by @AnnMarieW
 
 
 ### Fixed

--- a/PRs/app.py
+++ b/PRs/app.py
@@ -1,14 +1,47 @@
-from dash import *
-import dash_mantine_components as dmc
-from dash import _dash_renderer
 
+from random import randint
+import dash_mantine_components as dmc
+from dash import Dash, _dash_renderer, callback, Input, Output
 _dash_renderer._set_react_version("18.2.0")
 
-app = Dash(__name__)
+app = Dash(external_stylesheets=dmc.styles.ALL)
+
+chart = dmc.LineChart(
+    id="linechart-animation",
+    h=300,
+    dataKey="date",
+    data=[{}],
+    tooltipAnimationDuration=500,
+    lineProps={"isAnimationActive":True,
+                    "animationDuration": 500,
+                    "animationEasing": "ease-in-out",
+                    "animationBegin": 500},
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)
+
 
 app.layout = dmc.MantineProvider([
-    html.Div('Hi PyCafe'),
-    dmc.MultiSelect(data=['Test1', 'Test2'])
-    ])
+    dmc.Button("Update Chart", id="btn-linechart-animation"),
+    chart
+])
 
-app.run()
+@callback(
+    Output("linechart-animation", "data"),
+    Input("btn-linechart-animation", "n_clicks")
+)
+def update(n):
+    return [
+    {"date": "Mar 22", "Apples": 2890, "Oranges": 2338, "Tomatoes": randint(1000, 4000)},
+    {"date": "Mar 23", "Apples": 2756, "Oranges": 2103, "Tomatoes": randint(1000, 4000)},
+    {"date": "Mar 24", "Apples": 3322, "Oranges": 986, "Tomatoes": randint(1000, 4000)},
+    {"date": "Mar 25", "Apples": 3470, "Oranges": 2108, "Tomatoes": randint(1000, 4000)},
+    {"date": "Mar 26", "Apples": 3129, "Oranges": 1726, "Tomatoes": randint(1000, 4000)}
+]
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/src/ts/components/charts/AreaChart.tsx
+++ b/src/ts/components/charts/AreaChart.tsx
@@ -37,6 +37,8 @@ interface Props
     strokeWidth?: number;
     /** Props passed down to recharts `AreaChart` component */
     areaChartProps?: object;
+    /** Props passed down to recharts `Area` component */
+    areaProps?: object;
     /** Controls fill opacity of all areas, `0.2` by default */
     fillOpacity?: number;
     /** A tuple of colors used when `type="split"` is set, ignored in all other cases. A tuple may include theme colors reference or any valid CSS colors `['green.7', 'red.7']` by default. */
@@ -49,6 +51,8 @@ interface Props
     children?: React.ReactNode;
     /** Click data */
     clickData?: Record<string, any>;
+    /** Determines whether each point should have associated label, False by default  */
+    withPointLabels?: boolean;
 }
 
 /** AreaChart */

--- a/src/ts/components/charts/LineChart.tsx
+++ b/src/ts/components/charts/LineChart.tsx
@@ -33,12 +33,16 @@ interface Props
     strokeWidth?: number;
     /** Props passed down to recharts `LineChart` component */
     lineChartProps?: any;
+    /** Props passed down to recharts `Line` component */
+    lineProps?: any;
     /** Determines whether points with `null` values should be connected, `true` by default */
     connectNulls?: boolean;
     /** Additional components that are rendered inside recharts `AreaChart` component */
     children?: React.ReactNode;
     /** Click data */
     clickData?: Record<string, any>;
+    /** Determines whether each point should have associated label, False by default  */
+    withPointLabels?: boolean;
 }
 
 /** LineChart */

--- a/src/ts/components/charts/RadarChart.tsx
+++ b/src/ts/components/charts/RadarChart.tsx
@@ -16,6 +16,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     dataKey: string;
     /** Controls color of the grid lines. By default, color depends on the color scheme. */
     gridColor?: MantineColor;
+    /** Props passed down to recharts Legend component */
+    legendProps?: object;
     /** Controls color of all text elements. By default, color depends on the color scheme. */
     textColor?: MantineColor;
     /** Determines whether PolarGrid component should be displayed, `true` by default. */
@@ -26,6 +28,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     withPolarRadiusAxis?: boolean;
     /** Props passed down to recharts RadarChart component */
     radarChartProps?: object;
+    /** Props passed down to recharts Radar component in a dict */
+    radarProps?: any;
     /** Props passed down to recharts PolarGrid component */
     polarGridProps?: object;
     /** Props passed down to recharts PolarAngleAxis component */

--- a/src/ts/components/charts/ScatterChart.tsx
+++ b/src/ts/components/charts/ScatterChart.tsx
@@ -35,6 +35,8 @@ interface Props
     scatterProps?: object;
     /** Click data */
     clickData?: Record<string, any>;
+    /** If set, displays labels next to points for the given axis  */
+    pointLabels?: "x" | "y";
 }
 
 /** ScatterChart */

--- a/src/ts/components/charts/Sparkline.tsx
+++ b/src/ts/components/charts/Sparkline.tsx
@@ -24,6 +24,10 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     strokeWidth?: number;
     /** If set, `color` prop is ignored and chart color is determined by the difference between first and last value. */
     trendColors?: SparklineTrendColors;
+    /** Props passed down to recharts `Area` component */
+    areaProps?: object;
+    /** Determines whether points with `null` values should be connected, `true` by default */
+    connectNulls?: boolean;
 }
 
 /** Sparkline */

--- a/src/ts/props/charts.ts
+++ b/src/ts/props/charts.ts
@@ -46,4 +46,10 @@ export interface GridChartBaseProps {
     xAxisLabel?: string;
     /** A label to display next to the y-axis */
     yAxisLabel?: string;
+    /** Determines whether additional y-axis should be displayed on the right side of the chart, false by default*/
+    withRightYAxis?: boolean;
+    /** Props passed down to the YAxis recharts component rendered on the right side */
+    rightYAxisProps?: any;
+    /** Props passed down to the YAxis recharts component rendered on the right side */
+    rightYAxisLabel?: any;
 }


### PR DESCRIPTION
Closes #330 

This PR simply adds missing props for the charts:

- [x] line charts  
    - added `lineProps` - to pass props to recharts - necessary to enable animation
    - added `withPointLabels` to enable labeling all points
- [x] area charts
    - added `lineProps` - to pass props to recharts - necessary to enable animation
    - added `withPointLabels` to enable labeling all points  
- [x] scatter
 - added `pointsLabels` to add labels to either x or y points
 
- [x] sparkline
    -  added `areaProps`  to pass props to recharts

- [x] RadarChart
   - added `legentProps` and `radarProps` - to pass props to recharts
   
   
- [x] Line, Area, Bar, Scatter:

-` withRightYAxis   rightYAxisProps   rightYAxisLabel` for enabling and  formatting the right y axix

Docs are ready to go:  https://github.com/snehilvj/dmc-docs/pull/89

You can find a sample app of the chart animation based on a build from this PR on [PyCafe ](https://py.cafe/snippet/dash/v1?c=H4sIAIE2CWcC%2F6VVW2%2BbMBT%2BKxZPROIWyF1CarruYVqr7aF7qivkgBO8gmG2yRZF%2Be87NtC0SdNNKorAl%2FOdz%2Bec7zh7S9BfDRO0pFxJa4GsjMgcc%2F1OSsIV4zRJq7KuuDZAVyhXqpYL3693XkrW1N%2FkPhGKrUmqfMlpzortT1%2FD3Q7uHuF%2BGIzG02A%2Bnwb%2BBQY38IYjb%2BzWu8jlsOQSvvN%2B54XlICutMqqPiPlaVCUShGfwYQAVyswYV5h380sREImyMu1caKPewQ2MHZQYnKA8o4IKB6WkKFYkfXLQF143ykHfGgVfzF8beomkCmaQhWRLhWQVt7E1nHmhF2BrgDnmpK5RbFhs%2BkdRwUmRSLUrqMwpVTKGU3nt3Fve3hpImkNqAaS3biGOT3puY47gYVmMrQIWjRGkiZVEAS22nNYgj6Mg6MYZUeQr3QECRvTZRC%2FHD%2FvDYzdXVVUoVi97XzeNMN94%2FOxJM34XVS3jPbaYfDZdpoptwfPiXjS0sz19sEVOPQMAHZ2%2FA%2FhMJOMbbY4tSiR1GXcrqIP1b%2Bg13bCe6NCZSyoYlfHDEQzhcFLSlmFZ11AHcA7jtCoq0S4zkNim8ibYOjgXkN9Ah5s3oKuioe8C7ys4bfUGUlFSvETqYhl1GEl5BdlBHjqR3LV6hwJtGejS7uLTW9eNUkaUP2qtAWS0pMmMkFaKu2%2BKadCxmg3MHw3zVd8VnRbbnrAv6REZ2ZGjM9NK9jusGsKTtGDpkzTtA7%2BMrlFjzm7zwaJ1JKhqBEddmPte3jptd0SgMGxd9eVcoHA2D5yXZYKlKJo5rwqw6C8TexiANtEI3oM%2B%2Feck0RnJdDw5JRkG0YdIRqckURSGJyTz2eRDHOMzjtE0OA%2FkY9manJEMw%2FkJyXAa%2FlckoMe2EdgaJYnupSRBcQzIBK5%2BxpMEkO1BdKuIhtsZXTWbWF9SA%2F2XsmZwCvD%2B8Hj4CxCPN%2FgLBwAA)
