### PR TITLE
controlled popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ Note: `Chip` was available before but not documented. If you used `Chip` in dmc<
 - Added GitHub actions workflow for automated tests on PRs by @BSd3v
 
 
+
 ### Fixed
 
 - Excluded the `loading_state` prop from being passed to the DOM.   Added `data-dash-is-loading` attribute to
 components during callback execution, allowing custom CSS styling for loading states. #325 by @AnnMarieW
+- Enabled the `opened` prop to trigger callback #353 by @AnnMarieW
+
 
 ### Changed
 

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -5,25 +5,34 @@ import React from "react";
 
 interface Props extends PopoverProps, DashBaseProps {}
 
-/** Popover */
+/** Popover Component */
 const Popover = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, opened, setProps, loading_state, ...others } = props;
 
     return (
         <MantinePopover
             data-dash-is-loading={
                 (loading_state && loading_state.is_loading) || undefined
             }
+            opened={opened}
+            onClose={() => setProps({ opened: false })}
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
                 const childType = child.props._dashprivate_layout.type;
+
                 if (childType === "PopoverTarget") {
                     const { boxWrapperProps } = child.props;
                     const boxProps = { w: "fit-content", ...boxWrapperProps };
+
                     return (
                         <MantinePopover.Target key={index}>
-                            <Box {...boxProps}>{child}</Box>
+                            <Box
+                                onClick={() => setProps({ opened: !opened })}
+                                {...boxProps}
+                            >
+                                {child}
+                            </Box>
                         </MantinePopover.Target>
                     );
                 }
@@ -33,6 +42,8 @@ const Popover = (props: Props) => {
     );
 };
 
-Popover.defaultProps = {};
+Popover.defaultProps = {
+    opened: false,
+};
 
 export default Popover;

--- a/tests/test_popover.py
+++ b/tests/test_popover.py
@@ -23,7 +23,7 @@ def test_001po_popover(dash_duo):
         Input('popover', 'opened')
     )
     def update_output(opened):
-        return opened
+        return str(opened)
 
     dash_duo.start_server(app)
 

--- a/tests/test_popover.py
+++ b/tests/test_popover.py
@@ -28,7 +28,7 @@ def test_001po_popover(dash_duo):
     dash_duo.start_server(app)
 
     # Wait for the app to load
-    dash_duo.wait_for_element("#popover")
+    dash_duo.wait_for_text_to_equal("#output", "False")
 
     popover_btn = dash_duo.find_element("#btn")
     popover_btn.click()

--- a/tests/test_popover.py
+++ b/tests/test_popover.py
@@ -1,0 +1,42 @@
+from dash import Dash, html, Output, Input, _dash_renderer
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+def test_001po_popover(dash_duo):
+    app = Dash(__name__)
+
+    app.layout = dmc.MantineProvider(
+        html.Div([
+            dmc.Popover(
+                [dmc.PopoverTarget(dmc.Button("Toggle Popover", id="btn")),
+                dmc.PopoverDropdown(dmc.Text("This popover is opened"))],
+                id='popover',
+                opened=False
+            ),
+            html.Div(id='output')
+        ])
+    )
+
+    @app.callback(
+        Output('output', 'children'),
+        Input('popover', 'opened')
+    )
+    def update_output(opened):
+        return opened
+
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#popover")
+
+    popover_btn = dash_duo.find_element("#btn")
+    popover_btn.click()
+
+       # Verify the output
+    dash_duo.wait_for_text_to_equal("#output", "True")
+
+    popover_btn.click()
+    dash_duo.wait_for_text_to_equal("#output", "False")
+
+    assert dash_duo.get_logs() == []


### PR DESCRIPTION
Closes #328 

This allows the `opened` prop to trigger a callback

Here's a sample app

```python

import dash_mantine_components as dmc
from dash import Dash, _dash_renderer, Input, Output
_dash_renderer._set_react_version("18.2.0")


app = Dash(external_stylesheets=dmc.styles.ALL)

callback_popover = dmc.Popover(
    [
        dmc.PopoverTarget(dmc.Button("Toggle Popover")),
        dmc.PopoverDropdown(dmc.Text("This popover is opened on button click")),
    ],
    width=200,
    id="popover",
    opened=False
)

uncontrolled_popover = dmc.Popover(
    [
        dmc.PopoverTarget(dmc.Button("Toggle Popover")),
        dmc.PopoverDropdown(dmc.Text("This popover is opened on button click")),
    ],
    width=200,
)

component =  dmc.Box([
        dmc.Text(id="popover-container"),
        callback_popover,
        dmc.Text("This is an uncontrolled popover", mt=100),
        uncontrolled_popover

    ], p=20)


app.layout = dmc.MantineProvider(component)

@app.callback(
    Output("popover-container", "children"),
    Input("popover", "opened")
)
def update(opened):
    return f"Popover is opened? : {opened}"

if __name__ == "__main__":
    app.run(debug=True)


```