### PR TITLE
refactored Chip to removed controlled prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@
 ### Added
 
 - Added `autoplay` prop to the `Carousel` component #316 by @mmarfat 
-- Added the `ChipGroup` component and updated `Chip` to work with it. #327 by @AnnMarieW and @BSd3v
-Note: `Chip` was available before but not documented. If you used `Chip` in dmc<=0.14.5, you’ll now need to add `controlled=True` for it to work properly on its own.
+- Added the `ChipGroup` component and updated `Chip` to work with it. #327 and #355 by @AnnMarieW and @BSd3v
 - Added GitHub actions workflow for automated tests on PRs #333 by @BSd3v
 - Added new and missing props to the charts #349 by @AnnMarieW
-- RadioGroup and ChipGroup (in single mode) now have a `deselectable` argument to allow resetting the radio value #351
+- RadioGroup and ChipGroup (in single mode) now have a `deselectable` argument to allow resetting the radio value #351 by @RenaudLN
 
 
 

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -58,10 +58,11 @@ const Chip = (props: Props) => {
     const chipGroupContext = React.useContext(ChipGroupContext);
     const hasChipGroup = !!chipGroupContext;
 
-    // Change handler
     const onChange = (checked: boolean) => setProps({ checked });
 
-    // Build eventProps conditionally
+    // If the chip is part of a group, it is controlled by the ChipGroup context and
+    // only requires the onClick handler. Stand-alone chips are controlled components
+    // and need both the checked and onChange props to manage their own state.
     const eventProps = hasChipGroup
         ? { onClick: chipGroupContext?.chipOnClick }
         : { checked, onChange };
@@ -71,7 +72,7 @@ const Chip = (props: Props) => {
             data-dash-is-loading={
                 (loading_state && loading_state.is_loading) || undefined
             }
-            {...eventProps}  // Spread eventProps (onClick or checked/onChange)
+            {...eventProps}
             {...others}
         >
             {children}

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -60,9 +60,11 @@ const Chip = (props: Props) => {
 
     const { chipOnClick } = React.useContext(ChipGroupContext) || {};
 
+    console.log("chipOnClick", chipOnClick)
+
     return (
         <MantineChip
-            checked={checked}
+            checked={chipOnClick ? undefined : checked}
             onChange={onChange}
             onClick={chipOnClick}
             data-dash-is-loading={

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -54,22 +54,24 @@ const Chip = (props: Props) => {
         ...others
     } = props;
 
-    const onChange = (checked: boolean) => {
-        setProps({ checked });
-    };
+    // Fetch ChipGroupContext and check if the chip is part of a group
+    const chipGroupContext = React.useContext(ChipGroupContext);
+    const hasChipGroup = !!chipGroupContext;
 
-    const { chipOnClick } = React.useContext(ChipGroupContext) || {};
+    // Change handler
+    const onChange = (checked: boolean) => setProps({ checked });
 
-    console.log("chipOnClick", chipOnClick)
+    // Build eventProps conditionally
+    const eventProps = hasChipGroup
+        ? { onClick: chipGroupContext?.chipOnClick }
+        : { checked, onChange };
 
     return (
         <MantineChip
-            checked={chipOnClick ? undefined : checked}
-            onChange={onChange}
-            onClick={chipOnClick}
             data-dash-is-loading={
                 (loading_state && loading_state.is_loading) || undefined
             }
+            {...eventProps}  // Spread eventProps (onClick or checked/onChange)
             {...others}
         >
             {children}

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -8,7 +8,7 @@ import { BoxProps } from "props/box";
 import { DashBaseProps, PersistenceProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import React from "react";
-import ChipGroupContext from "./ChipGroupContext"
+import ChipGroupContext from "./ChipGroupContext";
 
 interface Props
     extends BoxProps,
@@ -39,8 +39,6 @@ interface Props
     disabled?: boolean;
     /** To be used with chip group */
     value?: string;
-    /** Set to True when using as a single chip (not in a chip group).  Default is False */
-    controlled?: boolean;
 }
 
 /** Chip for use with the ChipGroup. */
@@ -52,7 +50,6 @@ const Chip = (props: Props) => {
         persisted_props,
         persistence_type,
         checked,
-        controlled,
         loading_state,
         ...others
     } = props;
@@ -63,39 +60,24 @@ const Chip = (props: Props) => {
 
     const { chipOnClick } = React.useContext(ChipGroupContext) || {};
 
-    if (controlled) {
-        return (
-            <MantineChip
-                checked={checked}
-                onChange={onChange}
-                onClick={chipOnClick}
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
-                {...others}
-            >
-                {children}
-            </MantineChip>
-        );
-    } else {
-        return (
-            <MantineChip
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
-                onClick={chipOnClick}
-                {...others}
-            >
-                {children}
-            </MantineChip>
-        );
-    }
+    return (
+        <MantineChip
+            checked={checked}
+            onChange={onChange}
+            onClick={chipOnClick}
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            {...others}
+        >
+            {children}
+        </MantineChip>
+    );
 };
 
 Chip.defaultProps = {
     persisted_props: ["checked"],
     persistence_type: "local",
-    controlled: false,
 };
 
 export default Chip;


### PR DESCRIPTION
This PR refactors the Chip component to remove the `controlled` prop added in PR #327

It's based on the [review comment](https://github.com/snehilvj/dash-mantine-components/pull/351#discussion_r1798447880) in PR #351  

TODO 
- [x] verify that the `deselectable` still works correctly
- [x] updated docs to remove `controlled` prop