### PR TITLE
Reduce Highlight file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# Unreleased
+
+### Changed
+- Reduced the Highlight component file size. #366 by @AnnMarieW
+
 # 0.14.6 
 
 ### Added

--- a/src/ts/components/core/Highlight.tsx
+++ b/src/ts/components/core/Highlight.tsx
@@ -8,7 +8,7 @@ interface Props extends DashBaseProps, TextProps {
     highlight: string | string[];
     /** Key of `theme.colors` or any valid CSS color, passed to `Mark` component `color` prop, `yellow` by default */
     color?: MantineColor | string;
-    /** Styles applied to `mark` elements */
+    /** Styles applied to `mark` elements.  Note CSS properties are camelCase,  for example `highlightStyles={"backgroundColor": "blue"}` */
     highlightStyles?: {};
     /** Content */
     children?: string;

--- a/src/ts/components/core/Highlight.tsx
+++ b/src/ts/components/core/Highlight.tsx
@@ -9,7 +9,7 @@ interface Props extends DashBaseProps, TextProps {
     /** Key of `theme.colors` or any valid CSS color, passed to `Mark` component `color` prop, `yellow` by default */
     color?: MantineColor | string;
     /** Styles applied to `mark` elements */
-    highlightStyles?: React.CSSProperties;
+    highlightStyles?: {};
     /** Content */
     children?: string;
 }

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -28,6 +28,6 @@ def test_001hi_highlight_component(dash_duo):
 
     # Check if the "highlighted" text has a blue background and white text
     assert highlight_element.value_of_css_property("background-color") == "rgba(0, 0, 255, 1)"  # Blue background
-    assert highlight_element.value_of_css_property("color") == "rgb(255, 255, 255)"  # White text
+    assert highlight_element.value_of_css_property("color") == "rgba(255, 255, 255, 1)"  # White text
 
     assert dash_duo.get_logs() == []

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -1,0 +1,33 @@
+from dash import Dash, html
+import dash_mantine_components as dmc
+
+
+def test_highlight_component(dash_duo):
+    app = Dash(__name__)
+
+
+    app.layout = dmc.MantineProvider(
+        dmc.Highlight(
+            "You can change styles of highlighted parts",
+            highlight=["highlighted"],
+            highlightStyles={
+                "backgroundColor": "blue",
+                "color": "white",
+            },
+            id="highlight-text"
+        )
+    )
+
+    dash_duo.start_server(app)
+
+    # Wait for app to load
+    dash_duo.wait_for_text_to_equal("#highlight-text", "You can change styles of highlighted parts")
+
+    # Find the highlighted element within the dmc.Highlight component
+    highlight_element = dash_duo.find_element("#highlight-text mark")
+
+    # Check if the "highlighted" text has a blue background and white text
+    assert highlight_element.value_of_css_property("background-color") == "rgb(0, 0, 255)"  # Blue background
+    assert highlight_element.value_of_css_property("color") == "rgb(255, 255, 255)"  # White text
+
+    assert dash_duo.get_logs() == []

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -2,7 +2,7 @@ from dash import Dash, html
 import dash_mantine_components as dmc
 
 
-def test_highlight_component(dash_duo):
+def test_001hi_highlight_component(dash_duo):
     app = Dash(__name__)
 
 
@@ -27,7 +27,7 @@ def test_highlight_component(dash_duo):
     highlight_element = dash_duo.find_element("#highlight-text mark")
 
     # Check if the "highlighted" text has a blue background and white text
-    assert highlight_element.value_of_css_property("background-color") == "rgb(0, 0, 255)"  # Blue background
+    assert highlight_element.value_of_css_property("background-color") == "rgba(0, 0, 255, 1)"  # Blue background
     assert highlight_element.value_of_css_property("color") == "rgb(255, 255, 255)"  # White text
 
     assert dash_duo.get_logs() == []


### PR DESCRIPTION
This PR reduces the file size of `Highlight.py` from  442.9kB to 10.8kB

Previously, the file was over 7000 lines because it defined every possible CSS variable that could be used within the `HighlightStyles` prop.