### PR TITLE
[fix] Prevent loading from empty `src` in `Avatar` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Reduced the Highlight component file size. #366 by @AnnMarieW
 
+### Fixed
+- Prevent loading from empty `src` in `Avatar`. #372 by @mmarfat
+
 # 0.14.6 
 
 ### Added

--- a/src/ts/components/core/avatar/Avatar.tsx
+++ b/src/ts/components/core/avatar/Avatar.tsx
@@ -35,7 +35,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 /** Avatar */
 const Avatar = (props: Props) => {
     const { children, src, setProps, loading_state, ...others } = props;
-    const sanitizedSrc = useMemo(() => sanitizeUrl(src), [src]);
+    const sanitizedSrc = useMemo(() => (src ? sanitizeUrl(src) : undefined), [src]);
 
     return (
         <MantineAvatar

--- a/tests/test_avatar.py
+++ b/tests/test_avatar.py
@@ -13,4 +13,7 @@ def test_001av_avatar(dash_duo):
 
     dash_duo.start_server(app)
 
+    # Wait for the app to load
+    dash_duo.wait_for_text_to_equal("#avatar", "MK")
+
     assert dash_duo.get_logs() == []

--- a/tests/test_avatar.py
+++ b/tests/test_avatar.py
@@ -1,0 +1,15 @@
+from dash import Dash, html, _dash_renderer
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+def test_001av_avatar(dash_duo):
+    app = Dash(__name__)
+
+    avatar = dmc.Avatar("MK")
+
+    app.layout = dmc.MantineProvider(html.Div([avatar]))
+
+    dash_duo.start_server(app)
+
+    assert dash_duo.get_logs() == []

--- a/tests/test_avatar.py
+++ b/tests/test_avatar.py
@@ -6,7 +6,8 @@ _dash_renderer._set_react_version("18.2.0")
 def test_001av_avatar(dash_duo):
     app = Dash(__name__)
 
-    avatar = dmc.Avatar("MK")
+    avatar = dmc.Avatar("MK", id="avatar")
+
 
     app.layout = dmc.MantineProvider(html.Div([avatar]))
 


### PR DESCRIPTION
### Summary
This PR addresses an issue in the `Avatar` component where the component attempts to load a resource even when no `src` is provided. Previously, when `src` was missing or empty, it led to a `GET about:blank net::ERR_UNKNOWN_URL_SCHEME` error.

![avatar](https://github.com/user-attachments/assets/9848fdf0-f3b7-41dc-9f4f-32275f4d9768)

If `src` is empty or undefined, the component should not attempt to load an image. By adding this check, the component behaves more gracefully and avoids errors related to invalid URL schemes.

### Changes
- Updated the `sanitizedSrc` to return `undefined` when `src` is not provided.

### Example
```
import dash_mantine_components as dmc
from dash import Dash, html, _dash_renderer

_dash_renderer._set_react_version("18.2.0")

app = Dash()

avatars = [
    dmc.Avatar(src="https://avatars.githubusercontent.com/u/91216500?v=4"),
    dmc.Avatar("MK"), # This shouldn't output errors into the console
    dmc.Avatar(src="https://avatars.githubusercontent.com/u/91216500?v=4", children="MK")
]

app.layout = dmc.MantineProvider(
    html.Div(avatars)
)

if __name__ == '__main__':
    app.run_server(debug=True)
```

Let me know if you have any feedback or if you run into issues.
