### PR TITLE
Enable base64 images in Avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Prevent loading from empty `src` in `Avatar`. #372 by @mmarfat
+- Enable base64 images in Avatar #379 by @AnnMarieW
 
 # 0.14.6 
 

--- a/src/ts/components/core/avatar/Avatar.tsx
+++ b/src/ts/components/core/avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import { sanitizeUrl } from "@braintree/sanitize-url";
 import {
     Avatar as MantineAvatar,
     MantineColor,
@@ -34,15 +33,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Avatar */
 const Avatar = (props: Props) => {
-    const { children, src, setProps, loading_state, ...others } = props;
-    const sanitizedSrc = useMemo(() => (src ? sanitizeUrl(src) : undefined), [src]);
+    const { children, setProps, loading_state, ...others } = props;
 
     return (
         <MantineAvatar
             data-dash-is-loading={
                 (loading_state && loading_state.is_loading) || undefined
             }
-            src={sanitizedSrc}
             {...others}
         >
             {children}


### PR DESCRIPTION
closes #374 

Removed sanitizing url because it's not necessary for image components.

dmc.Avatar renders as an html Img