### PR TITLE
added new props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `autoScroll` prop to the `Carousel` component #373 by @mmarfat 
+- Added `withLegend` to `RadarChart`, and `maxBarWidth`, `minBarSize` to `BarChart`. #395 by @AnnMarieW
 
 ### Changed
 - Reduced the Highlight component file size  #366 by @AnnMarieW

--- a/src/ts/components/charts/BarChart.tsx
+++ b/src/ts/components/charts/BarChart.tsx
@@ -37,6 +37,10 @@ interface Props
     /** Determines whether a label with bar value should be displayed on top of each bar,
      incompatible with type="stacked" and type="percent", false by default */
     withBarValueLabel?: boolean;
+    /** Sets minimum height of the bar in px, `0` by default */
+    minBarSize?: number;
+    /** Maximum bar width in px */
+    maxBarWidth?: number;
 }
 
 /** BarChart */

--- a/src/ts/components/charts/RadarChart.tsx
+++ b/src/ts/components/charts/RadarChart.tsx
@@ -20,6 +20,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     legendProps?: object;
     /** Controls color of all text elements. By default, color depends on the color scheme. */
     textColor?: MantineColor;
+    /** Determines whether chart legend should be displayed, `false` by default */
+    withLegend?: boolean;
     /** Determines whether PolarGrid component should be displayed, `true` by default. */
     withPolarGrid?: boolean;
     /** Determines whether PolarAngleAxis component should be displayed, `true` by default */


### PR DESCRIPTION
closes #394 

`withLegend` was added to RadarChart in Mantine 7.11
`maxBarWidth` was added to BarChart in Mantine 7.13

`minBarSize` - added for completeness.  I'm not sure when it was added to Mantine, but IMHO, it's misleading and I'm not sure I'll add this example to the docs https://mantine.dev/charts/bar-chart/#minimum-bar-size

