### PR TITLE
Update date components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+# Unreleased
+
+### Added 
+
+- New additons to Date components #405 by @AnnMarieW
+  - `DatePicker` - The `debounce` prop can now be `True` `False` or `number` of ms delay before updating.  When True, the value updates on blur. 
+  - Added missing `highlightToday` prop on all Date components with calendars.
+  - `DateInput` updates properly now when clearable=True 
+
+
 # 0.14.7
 
 ### Added

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -1,5 +1,5 @@
 import { CalendarLevel, DateInput as MantineDateInput } from "@mantine/dates";
-import { useDebouncedValue, useDidUpdate } from "@mantine/hooks";
+import { useDebouncedValue, useDidUpdate, useFocusWithin } from "@mantine/hooks";
 import { BoxProps } from "props/box";
 import { DashBaseProps, PersistenceProps, DebounceProps } from "props/dash";
 import {
@@ -77,11 +77,22 @@ const DateInput = (props: Props) => {
     const debounceValue = typeof debounce === 'number' ? debounce : 0;
     const [debounced] = useDebouncedValue(date, debounceValue);
 
+    const { ref, focused } = useFocusWithin();
+
     useDidUpdate(() => {
         if (typeof debounce === 'number' || debounce === false) {
             setProps({ value: dateToString(date) });
         }
     }, [debounced]);
+
+    useDidUpdate(() => {
+        // Ensure the value prop is updated when the date is cleared by clicking the "X" button,
+        // even if the input does not have focus.
+        if (!focused) {
+            setProps({ value: dateToString(date)})
+        }
+    }, [date]);
+
 
     useDidUpdate(() => {
         setDate(stringToDate(value));
@@ -109,19 +120,21 @@ const DateInput = (props: Props) => {
     };
 
     return (
-        <MantineDateInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
-            onBlur={handleBlur}
-            onKeyDown={handleKeyDown}
-            onChange={setDate}
-            value={date}
-            minDate={stringToDate(minDate)}
-            maxDate={stringToDate(maxDate)}
-            excludeDate={isExcluded}
-            {...others}
-        />
+        <div ref={ref}>
+            <MantineDateInput
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                onChange={setDate}
+                value={date}
+                minDate={stringToDate(minDate)}
+                maxDate={stringToDate(maxDate)}
+                excludeDate={isExcluded}
+                {...others}
+            />
+        </div>
     );
 };
 

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -83,15 +83,13 @@ const DateInput = (props: Props) => {
         if (typeof debounce === 'number' || debounce === false) {
             setProps({ value: dateToString(date) });
         }
-    }, [debounced]);
 
-    useDidUpdate(() => {
         // Ensure the value prop is updated when the date is cleared by clicking the "X" button,
         // even if the input does not have focus.
-        if (!focused) {
+        if (!focused && debounce === true) {
             setProps({ value: dateToString(date)})
         }
-    }, [date]);
+    }, [debounced]);
 
 
     useDidUpdate(() => {

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -50,6 +50,8 @@ interface Props
     level?: CalendarLevel;
     /** Specifies days that should be disabled */
     disabledDates?: string[];
+    /** Determines whether today should be highlighted with a border, false by default */
+    highlightToday?: boolean;
 }
 
 /** DateInput */

--- a/src/ts/components/dates/DatePicker.tsx
+++ b/src/ts/components/dates/DatePicker.tsx
@@ -1,32 +1,32 @@
-import { DatePickerInput } from "@mantine/dates";
-import { useDebouncedValue, useDidUpdate } from "@mantine/hooks";
-import { BoxProps } from "props/box";
-import { DashBaseProps, PersistenceProps } from "props/dash";
-import { DateInputSharedProps, DatePickerBaseProps } from "props/dates";
-import { StylesApiProps } from "props/styles";
-import React, { useState } from "react";
+import { DatePickerInput } from '@mantine/dates';
+import { useDebouncedValue, useDidUpdate, useFocusWithin } from '@mantine/hooks';
+import { BoxProps } from 'props/box';
+import { DashBaseProps, PersistenceProps } from 'props/dash';
+import { DateInputSharedProps, DatePickerBaseProps } from 'props/dates';
+import { StylesApiProps } from 'props/styles';
+import React, { useState } from 'react';
 import {
     isDisabled,
     stringToDate,
     toDates,
     toStrings,
-} from "../../utils/dates";
+} from '../../utils/dates';
 
-interface Props
-    extends DashBaseProps,
-        PersistenceProps,
-        BoxProps,
-        DateInputSharedProps,
-        DatePickerBaseProps,
-        StylesApiProps {
-    /** Dayjs format to display input value, "MMMM D, YYYY" by default  */
+interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputSharedProps, DatePickerBaseProps, StylesApiProps {
+    /** Dayjs format to display input value, "MMMM D, YYYY" by default */
     valueFormat?: string;
     /** Specifies days that should be disabled */
     disabledDates?: string[];
+    /** Determines whether today should be highlighted with a border, false by default */
+    highlightToday?: boolean;
     /** An integer that represents the number of times that this element has been submitted */
     n_submit?: number;
-    /** Debounce time in ms */
-    debounce?: number;
+    /**
+     * (boolean | number; default False): If True, changes to input will be sent back to the Dash server only on enter or when losing focus.
+     * If it's False, it will send the value back on every change. If a number, it will not send anything back to the Dash server until
+     * the user has stopped typing for that number of milliseconds.
+     */
+    debounce?: boolean | number;
 }
 
 /** DatePicker */
@@ -35,6 +35,7 @@ const DatePicker = (props: Props) => {
         setProps,
         loading_state,
         n_submit,
+        type,
         value,
         debounce,
         minDate,
@@ -47,46 +48,68 @@ const DatePicker = (props: Props) => {
     } = props;
 
     const [date, setDate] = useState(toDates(value));
-    const [debounced] = useDebouncedValue(date, debounce);
+
+    const debounceValue = typeof debounce === 'number' ? debounce : 0;
+    const [debounced] = useDebouncedValue(date, debounceValue);
+    const { ref, focused } = useFocusWithin();
 
     useDidUpdate(() => {
-        setProps({ value: toStrings(date) });
+        if (typeof debounce === 'number' || debounce === false) {
+            setProps({ value: toStrings(date) });
+        }
     }, [debounced]);
 
     useDidUpdate(() => {
-        setDate(toDates(value));
+        // Clears value when X is clicked
+        if (focused) {
+            setProps({ value: toStrings(date) });
+        }
+    }, [date]);
+
+    useDidUpdate(() => {
+        // If type is multiple or range, sets default value to a list
+        setDate(type !== 'default' && !value ? [] : toDates(value));
     }, [value]);
 
-    const handleKeyDown = (ev) => {
-        if (ev.key === "Enter") {
+    const handleKeyDown = (ev: React.KeyboardEvent) => {
+        // Enter key opens calendar, so don't call setProps
+        if (ev.key === 'Enter') {
             setProps({ n_submit: n_submit + 1 });
         }
     };
 
-    const isExcluded = (date: Date) => {
-        return isDisabled(date, disabledDates || []);
+    const handleBlur = () => {
+        // Don't include n_blur counter because onBlur is called when the calendar is opened
+        if (debounce === true) {
+            setProps({ value: toStrings(date) });
+        }
     };
 
+    const isExcluded = (date: Date) => isDisabled(date, disabledDates || []);
+
     return (
-        <DatePickerInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
-            wrapperProps={{ autoComplete: "off" }}
-            onKeyDown={handleKeyDown}
-            onChange={setDate}
-            value={date}
-            minDate={stringToDate(minDate)}
-            maxDate={stringToDate(maxDate)}
-            excludeDate={isExcluded}
-            {...others}
-        />
+        <div ref={ref}>
+            <DatePickerInput
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                onChange={setDate}
+                value={date}
+                type={type}
+                minDate={stringToDate(minDate)}
+                maxDate={stringToDate(maxDate)}
+                excludeDate={isExcluded}
+                {...others}
+            />
+        </div>
     );
 };
 
 DatePicker.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
+    persisted_props: ['value'],
+    persistence_type: 'local',
     debounce: 0,
     n_submit: 0,
 };

--- a/src/ts/components/dates/DatePicker.tsx
+++ b/src/ts/components/dates/DatePicker.tsx
@@ -112,6 +112,7 @@ DatePicker.defaultProps = {
     persistence_type: 'local',
     debounce: 0,
     n_submit: 0,
+    type: 'default',
 };
 
 export default DatePicker;

--- a/src/ts/components/dates/DateTimePicker.tsx
+++ b/src/ts/components/dates/DateTimePicker.tsx
@@ -40,6 +40,8 @@ interface Props
     n_submit?: number;
     /** Debounce time in ms */
     debounce?: number;
+    /** Determines whether today should be highlighted with a border, false by default */
+    highlightToday?: boolean;
 }
 
 /** DateTimePicker */

--- a/tests/dates/test_date_picker.py
+++ b/tests/dates/test_date_picker.py
@@ -1,5 +1,7 @@
+import pytest
 import time
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import TimeoutException
 from dash import Dash, html,  Output, Input, _dash_renderer
 import dash_mantine_components as dmc
 
@@ -173,8 +175,8 @@ def test_002dp_datepicker(dash_duo):
     picker_elem3.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ARROW_DOWN, Keys.ENTER, Keys.ESCAPE)
 
     # initially no change
-    time.sleep(.5)
-    dash_duo.wait_for_text_to_equal("#out-2000", "None", timeout=1)
+    with pytest.raises(TimeoutException):
+        dash_duo.wait_for_text_to_equal("#out-2000", "['2024-10-01', '2024-10-08']", timeout=1)
 
     # but do expect that it is eventually called
     dash_duo.wait_for_text_to_equal("#out-2000", "['2024-10-01', '2024-10-08']")

--- a/tests/dates/test_date_picker.py
+++ b/tests/dates/test_date_picker.py
@@ -1,0 +1,183 @@
+import time
+from selenium.webdriver.common.keys import Keys
+from dash import Dash, html,  Output, Input, _dash_renderer
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+
+def make_app(**kwargs):
+    app = Dash(external_stylesheets=dmc.styles.ALL)
+
+    debounce = dmc.Stack(
+        [
+            dmc.Box(id="out-true"),
+            dmc.DatePicker(
+                label="debounce=True",
+                id="debounce-true",
+                debounce=True,
+                minDate="2024-10-01",
+                maxDate="2024-10-31",
+                **kwargs
+            ),
+            dmc.Box(id="out-false"),
+            dmc.DatePicker(
+                label="debounce=False",
+                id="debounce-false",
+                debounce=False,
+                minDate="2024-10-01",
+                maxDate="2024-10-31",
+                **kwargs
+            ),
+            dmc.Box(id="out-2000"),
+            dmc.DatePicker(
+                label="debounce=2000",
+                id="debounce-2000",
+                debounce=2000,
+                minDate="2024-10-01",
+                maxDate="2024-10-31",
+                **kwargs
+            ),
+        ]
+    )
+
+    app.layout = dmc.MantineProvider(debounce)
+
+    @app.callback(
+        Output("out-true", "children"),
+        Output("out-false", "children"),
+        Output("out-2000", "children"),
+        Input("debounce-true", "value"),
+        Input("debounce-false", "value"),
+        Input("debounce-2000", "value"),
+    )
+    def update(d_true, d_false, d_2000):
+        return str(d_true), str(d_false), str(d_2000)
+
+    return app
+
+
+# type=default (select one date)
+def test_001dp_datepicker(dash_duo):
+
+    app = make_app()
+
+    dash_duo.start_server(app)
+    # debounce=True
+    # Wait for the app to load
+    dash_duo.wait_for_text_to_equal("#out-true", "None")
+    # enter a value
+    input_elem = dash_duo.find_element("#debounce-true")
+    # focus element to open calendar
+    input_elem.click()
+
+    picker_elem = dash_duo.find_element(".mantine-Popover-dropdown")
+
+    # select a day from the calendar with the keyboard
+    picker_elem.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ESCAPE)
+
+    # verify the output has not been updated because debounce=True
+    dash_duo.wait_for_text_to_equal("#out-true", "None")
+
+    input_elem.send_keys(Keys.TAB)
+    # verify the output has been updated after input loses focus
+    dash_duo.wait_for_text_to_equal("#out-true", "2024-10-01")
+
+    # debounce=False
+    # verify output is blank
+    dash_duo.wait_for_text_to_equal("#out-false", "None")
+    # enter a value
+    input_elem = dash_duo.find_element("#debounce-false")
+    # focus element to open calendar
+    input_elem.click()
+
+
+    time.sleep(.5)
+    picker_elem2 = dash_duo.find_element(".mantine-Popover-dropdown")
+
+    # select a day from the calendar with the keyboard
+    picker_elem2.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ESCAPE, Keys.TAB)
+    # verify the output has been updated without pressing enter or losing focus
+    dash_duo.wait_for_text_to_equal("#out-false", "2024-10-01")
+
+
+    # debounce is an number
+    input_elem = dash_duo.find_element("#debounce-2000")
+    input_elem.click()
+
+    time.sleep(.5)
+    # select a day from the calendar with the keyboard
+    picker_elem3 = dash_duo.find_element(".mantine-Popover-dropdown")
+    picker_elem3.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER)
+
+
+    # initially no change
+    time.sleep(.5)
+    dash_duo.wait_for_text_to_equal("#out-2000", "None", timeout=1)
+
+    # but do expect that it is eventually called
+    dash_duo.wait_for_text_to_equal("#out-2000", "2024-10-01")
+
+    assert dash_duo.get_logs() == []
+
+# type=range
+def test_002dp_datepicker(dash_duo):
+    app = make_app(type="range")
+
+    dash_duo.start_server(app)
+
+    # 1. debounce=True
+    # Wait for the app to load
+    dash_duo.wait_for_text_to_equal("#out-true", "None")
+    # enter a value
+    input_elem = dash_duo.find_element("#debounce-true")
+    # focus element to open calendar
+    input_elem.click()
+
+    picker_elem = dash_duo.find_element(".mantine-Popover-dropdown")
+
+    # select a day from the calendar with the keyboard
+    picker_elem.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ARROW_DOWN, Keys.ENTER, Keys.ESCAPE)
+
+    # verify the output has not been updated because debounce=True
+    dash_duo.wait_for_text_to_equal("#out-true", "None")
+
+    input_elem.send_keys(Keys.TAB)
+    # verify the output has been updated after input loses focus
+    dash_duo.wait_for_text_to_equal("#out-true", "['2024-10-01', '2024-10-08']")
+
+    # 2. debounce=False
+    # verify output is blank
+    dash_duo.wait_for_text_to_equal("#out-false", "None")
+    # enter a value
+    input_elem = dash_duo.find_element("#debounce-false")
+    # focus element to open calendar
+    input_elem.click()
+
+    time.sleep(.5)
+    picker_elem2 = dash_duo.find_element(".mantine-Popover-dropdown")
+
+    # select a day from the calendar with the keyboard
+    picker_elem2.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ARROW_DOWN, Keys.ENTER, Keys.ESCAPE)
+
+    # verify the output has been updated without pressing enter or losing focus
+    dash_duo.wait_for_text_to_equal("#out-false", "['2024-10-01', '2024-10-08']")
+
+    # 3. debounce is an number
+    input_elem = dash_duo.find_element("#debounce-2000")
+    input_elem.click()
+
+    time.sleep(.5)
+    # select a day from the calendar with the keyboard
+    picker_elem3 = dash_duo.find_element(".mantine-Popover-dropdown")
+    picker_elem3.send_keys(Keys.TAB, Keys.TAB, Keys.ENTER, Keys.ARROW_DOWN, Keys.ENTER, Keys.ESCAPE)
+
+    # initially no change
+    time.sleep(.5)
+    dash_duo.wait_for_text_to_equal("#out-2000", "None", timeout=1)
+
+    # but do expect that it is eventually called
+    dash_duo.wait_for_text_to_equal("#out-2000", "['2024-10-01', '2024-10-08']")
+
+    assert dash_duo.get_logs() == []
+


### PR DESCRIPTION
Closes #403 

- add `debounce=True` to `DatePicker`
- add missing `highlightToday` prop
- handle `clearable` `DateInput` when `debounce=True` 
- added test

**Notes on adding `debounce` to the `DatePicker`**

The input field in `DatePicker` behaves differently from `DateInput` in Mantine:

- In `DateInput`, users can type a date directly into the Input field (or select from a calendar).  Pressing Enter will make the input lose focus, updating the value.
- In `DatePicker` users cannot type directly into the input field. Pressing Enter or clicking on the field opens the calendar, shifting the focus to it. The value is only updated by selecting dates from the calendar.  The `n_submit` prop (counter for enter key pressed)  has limited use here and is being kept only for legacy reasons (remove in a future major release?).
- `onBlur`  Behavior:
  - In `DateInput`, the onBlur counter `n_blur` is useful for detecting when a user finishes typing or selecting a date.
  - In `DatePicker`, `n_blur` isn’t useful because the focus shifts  from the input to the calendar triggering the counter. The `n_blur` counter doesn't indicate that the user has finished entering an input, so it is not included in this component.


