### PR TITLE
fix debounce when deleting items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Unreleased
+
+### Fixed
+-  In MultiSelect, enable the debounce to work when deleting items when the dropdown is closed when debounce is a number. #407 by @AnnMarieW
+
+
 # 0.14.7
 
 ### Added

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -75,15 +75,14 @@ const MultiSelect = (props: Props) => {
         if (typeof debounce === 'number' || debounce === false) {
             setProps({ value: debounced });
         }
-    }, [debounced]);
 
-    useDidUpdate(() => {
         // Update the value prop if an item is removed by clicking the "x" on the pill,
         // even if the input is not focused at the time
-        if (!focused) {
-            setProps({ value: selected})
+        if (!focused && debounce === true) {
+            setProps({ value: debounced})
         }
-    }, [selected]);
+    }, [debounced]);
+
 
     useDidUpdate(() => {
             setSelected(value ?? []);

--- a/tests/combobox/test_multi_select_debounce.py
+++ b/tests/combobox/test_multi_select_debounce.py
@@ -173,7 +173,7 @@ def test_003mu_multi_select_debounce(dash_duo):
 
     # Verify the value updates after debounce time when the input is not focused
     with pytest.raises(TimeoutException):
-        dash_duo.wait_for_text_to_equal("#output", '["a"]', timeout=1)
+        dash_duo.wait_for_text_to_equal("#output", "Selected: []", timeout=1)
 
     # but do expect that it is eventually called
     dash_duo.wait_for_text_to_equal("#output", "Selected: []")


### PR DESCRIPTION
Closes #406 

This PR will enable the debounce to work when clearing items when the dropdown is closed when debounce is a number of ms to delay