### PR TITLE
DatePicker renamed to DatePickerInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 # Unreleased
 
+### Added
+
 - New additons to Date components #405 by @AnnMarieW
   - `DatePicker` - The `debounce` prop can now be `True` `False` or `number` of ms delay before updating.  When True, the value updates on blur. 
   - Added missing `highlightToday` prop on all Date components with calendars.
   - `DateInput` updates properly now when clearable=True 
 
 - Enabled custom icons in `Checkbox` Added `icon` and `indeterminateIcon` props #408 by @snehilvj 
+
+### Changed
+- **Breaking Change:** Renamed `DatePicker` to `DatePickerInput` so component names are aligned with the upstream Mantine library.  #414 by @AnnMarieW
+
+
 
 ### Fixed
 -  In MultiSelect, enable the debounce to work when deleting items when the dropdown is closed when debounce is a number. #407 by @AnnMarieW

--- a/src/ts/components/dates/DatePicker.tsx
+++ b/src/ts/components/dates/DatePicker.tsx
@@ -1,16 +1,11 @@
-import { DatePickerInput } from '@mantine/dates';
+// DatePicker placeholder - name changed to DatePickerInput
+
+// Need to define all the props from the old DatePicker component otherwise Dash will throw a TypeError for unexpected keywords
 import { useDebouncedValue, useDidUpdate, useFocusWithin } from '@mantine/hooks';
 import { BoxProps } from 'props/box';
 import { DashBaseProps, PersistenceProps } from 'props/dash';
 import { DateInputSharedProps, DatePickerBaseProps } from 'props/dates';
 import { StylesApiProps } from 'props/styles';
-import React, { useState } from 'react';
-import {
-    isDisabled,
-    stringToDate,
-    toDates,
-    toStrings,
-} from '../../utils/dates';
 
 interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputSharedProps, DatePickerBaseProps, StylesApiProps {
     /** Dayjs format to display input value, "MMMM D, YYYY" by default */
@@ -29,90 +24,10 @@ interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputShar
     debounce?: boolean | number;
 }
 
-/** DatePicker */
-const DatePicker = (props: Props) => {
-    const {
-        setProps,
-        loading_state,
-        n_submit,
-        type,
-        value,
-        debounce,
-        minDate,
-        maxDate,
-        disabledDates,
-        persistence,
-        persisted_props,
-        persistence_type,
-        ...others
-    } = props;
-
-    const [date, setDate] = useState(toDates(value));
-
-    const debounceValue = typeof debounce === 'number' ? debounce : 0;
-    const [debounced] = useDebouncedValue(date, debounceValue);
-    const { ref, focused } = useFocusWithin();
-
-    useDidUpdate(() => {
-        if (typeof debounce === 'number' || debounce === false) {
-            setProps({ value: toStrings(date) });
-        }
-    }, [debounced]);
-
-    useDidUpdate(() => {
-        // Clears value when X is clicked
-        if (focused) {
-            setProps({ value: toStrings(date) });
-        }
-    }, [date]);
-
-    useDidUpdate(() => {
-        // If type is multiple or range, sets default value to a list
-        setDate(type !== 'default' && !value ? [] : toDates(value));
-    }, [value]);
-
-    const handleKeyDown = (ev: React.KeyboardEvent) => {
-        // Enter key opens calendar, so don't call setProps
-        if (ev.key === 'Enter') {
-            setProps({ n_submit: n_submit + 1 });
-        }
-    };
-
-    const handleBlur = () => {
-        // Don't include n_blur counter because onBlur is called when the calendar is opened
-        if (debounce === true) {
-            setProps({ value: toStrings(date) });
-        }
-    };
-
-    const isExcluded = (date: Date) => isDisabled(date, disabledDates || []);
-
-    return (
-        <div ref={ref}>
-            <DatePickerInput
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
-                onBlur={handleBlur}
-                onKeyDown={handleKeyDown}
-                onChange={setDate}
-                value={date}
-                type={type}
-                minDate={stringToDate(minDate)}
-                maxDate={stringToDate(maxDate)}
-                excludeDate={isExcluded}
-                {...others}
-            />
-        </div>
+const DatePicker = ( props: Props) => {
+    throw new Error(
+        "The 'DatePicker' component has been renamed to 'DatePickerInput'. Please update your app to use 'DatePickerInput' instead."
     );
-};
-
-DatePicker.defaultProps = {
-    persisted_props: ['value'],
-    persistence_type: 'local',
-    debounce: 0,
-    n_submit: 0,
-    type: 'default',
 };
 
 export default DatePicker;

--- a/src/ts/components/dates/DatePickerInput.tsx
+++ b/src/ts/components/dates/DatePickerInput.tsx
@@ -1,0 +1,118 @@
+import { DatePickerInput as MantineDatePickerInput } from '@mantine/dates';
+import { useDebouncedValue, useDidUpdate, useFocusWithin } from '@mantine/hooks';
+import { BoxProps } from 'props/box';
+import { DashBaseProps, PersistenceProps } from 'props/dash';
+import { DateInputSharedProps, DatePickerBaseProps } from 'props/dates';
+import { StylesApiProps } from 'props/styles';
+import React, { useState } from 'react';
+import {
+    isDisabled,
+    stringToDate,
+    toDates,
+    toStrings,
+} from '../../utils/dates';
+
+interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputSharedProps, DatePickerBaseProps, StylesApiProps {
+    /** Dayjs format to display input value, "MMMM D, YYYY" by default */
+    valueFormat?: string;
+    /** Specifies days that should be disabled */
+    disabledDates?: string[];
+    /** Determines whether today should be highlighted with a border, false by default */
+    highlightToday?: boolean;
+    /** An integer that represents the number of times that this element has been submitted */
+    n_submit?: number;
+    /**
+     * (boolean | number; default False): If True, changes to input will be sent back to the Dash server only on enter or when losing focus.
+     * If it's False, it will send the value back on every change. If a number, it will not send anything back to the Dash server until
+     * the user has stopped typing for that number of milliseconds.
+     */
+    debounce?: boolean | number;
+}
+
+/** DatePickerInput */
+const DatePickerInput = (props: Props) => {
+    const {
+        setProps,
+        loading_state,
+        n_submit,
+        type,
+        value,
+        debounce,
+        minDate,
+        maxDate,
+        disabledDates,
+        persistence,
+        persisted_props,
+        persistence_type,
+        ...others
+    } = props;
+
+    const [date, setDate] = useState(toDates(value));
+
+    const debounceValue = typeof debounce === 'number' ? debounce : 0;
+    const [debounced] = useDebouncedValue(date, debounceValue);
+    const { ref, focused } = useFocusWithin();
+
+    useDidUpdate(() => {
+        if (typeof debounce === 'number' || debounce === false) {
+            setProps({ value: toStrings(date) });
+        }
+    }, [debounced]);
+
+    useDidUpdate(() => {
+        // Clears value when X is clicked
+        if (focused) {
+            setProps({ value: toStrings(date) });
+        }
+    }, [date]);
+
+    useDidUpdate(() => {
+        // If type is multiple or range, sets default value to a list
+        setDate(type !== 'default' && !value ? [] : toDates(value));
+    }, [value]);
+
+    const handleKeyDown = (ev: React.KeyboardEvent) => {
+        // Enter key opens calendar, so don't call setProps
+        if (ev.key === 'Enter') {
+            setProps({ n_submit: n_submit + 1 });
+        }
+    };
+
+    const handleBlur = () => {
+        // Don't include n_blur counter because onBlur is called when the calendar is opened
+        if (debounce === true) {
+            setProps({ value: toStrings(date) });
+        }
+    };
+
+    const isExcluded = (date: Date) => isDisabled(date, disabledDates || []);
+
+    return (
+        <div ref={ref}>
+            <MantineDatePickerInput
+                data-dash-is-loading={
+                    (loading_state && loading_state.is_loading) || undefined
+                }
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                onChange={setDate}
+                value={date}
+                type={type}
+                minDate={stringToDate(minDate)}
+                maxDate={stringToDate(maxDate)}
+                excludeDate={isExcluded}
+                {...others}
+            />
+        </div>
+    );
+};
+
+DatePickerInput.defaultProps = {
+    persisted_props: ['value'],
+    persistence_type: 'local',
+    debounce: 0,
+    n_submit: 0,
+    type: 'default',
+};
+
+export default DatePickerInput;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -134,6 +134,7 @@ import FloatingTooltip from "./components/core/tooltip/FloatingTooltip";
 import Tooltip from "./components/core/tooltip/Tooltip";
 import DateInput from "./components/dates/DateInput";
 import DatePicker from "./components/dates/DatePicker";
+import DatePickerInput from "./components/dates/DatePickerInput";
 import DateTimePicker from "./components/dates/DateTimePicker";
 import DatesProvider from "./components/dates/DatesProvider";
 import MonthPickerInput from "./components/dates/MonthPickerInput";
@@ -201,6 +202,7 @@ export {
     Container,
     DateInput,
     DatePicker,
+    DatePickerInput,
     DateTimePicker,
     DatesProvider,
     Divider,

--- a/tests/dates/test_date_picker.py
+++ b/tests/dates/test_date_picker.py
@@ -14,7 +14,7 @@ def make_app(**kwargs):
     debounce = dmc.Stack(
         [
             dmc.Box(id="out-true"),
-            dmc.DatePicker(
+            dmc.DatePickerInput(
                 label="debounce=True",
                 id="debounce-true",
                 debounce=True,
@@ -23,7 +23,7 @@ def make_app(**kwargs):
                 **kwargs
             ),
             dmc.Box(id="out-false"),
-            dmc.DatePicker(
+            dmc.DatePickerInput(
                 label="debounce=False",
                 id="debounce-false",
                 debounce=False,
@@ -32,7 +32,7 @@ def make_app(**kwargs):
                 **kwargs
             ),
             dmc.Box(id="out-2000"),
-            dmc.DatePicker(
+            dmc.DatePickerInput(
                 label="debounce=2000",
                 id="debounce-2000",
                 debounce=2000,
@@ -60,7 +60,7 @@ def make_app(**kwargs):
 
 
 # type=default (select one date)
-def test_001dp_datepicker(dash_duo):
+def test_001dp_DatePickerInput(dash_duo):
 
     app = make_app()
 
@@ -123,7 +123,7 @@ def test_001dp_datepicker(dash_duo):
     assert dash_duo.get_logs() == []
 
 # type=range
-def test_002dp_datepicker(dash_duo):
+def test_002dp_DatePickerInput(dash_duo):
     app = make_app(type="range")
 
     dash_duo.start_server(app)


### PR DESCRIPTION
This PR renames the DatePicker to DatePickerInput so the component name is aligned with the upstream Mantine library.
For more information see #410

Until the real DatePicker component is added, you will see an error message:

![image](https://github.com/user-attachments/assets/0d5cdcdc-27ac-429c-8794-d111683d94df)


Here is a sample app to show the error message for the old component name, and that the new component works as expected
```python
from datetime import datetime
import dash_mantine_components as dmc
from dash import Dash, _dash_renderer
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

component = dmc.Stack(
    [
        dmc.DatePicker(
            value=datetime.now().date(),
            label="Date not clearable",
           # w=200,
        ),
        dmc.DatePickerInput(
            value=datetime.now().date(),
            label="Date clearable",
            w=200,
            clearable=True,
        ),
    ]
)


app.layout = dmc.MantineProvider(
    component
)

if __name__ == "__main__":
    app.run(debug=True)
    
 ```