### PR TITLE
Add position prop to Notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - added `hoverData`, `hoverSeriesName`, `clickSeriesName` and `highlightHover` props to `AreaChart`, `LineChart`, `BarChart`, and `CompositeChart`
   - added `hoverData`, `hoverSeriesName`, `clickSeriesName` to `PieChart`,   `DonutChart`, `ScatterChart`
 - New props for triggering dash callbacks on input components: `n_submit` `n_blur` #383 by @AnnMarieW 
+- Added `position` prop to `Notification #419 by @AnnMarieW
 
 
 ### Changed

--- a/src/ts/components/extensions/notifications/Notification.tsx
+++ b/src/ts/components/extensions/notifications/Notification.tsx
@@ -32,6 +32,9 @@ interface Props extends BoxProps, StylesApiProps, Omit<DashBaseProps, "id"> {
     autoClose?: boolean | number;
     /** action */
     action: "show" | "update" | "hide" | "clean" | "cleanQueue";
+    /** Position on the screen to display the notification.  */
+    position?: 'top-left' |  'top-right' | 'bottom-left' | 'bottom-right' | 'top-center' | 'bottom-center';
+
 }
 
 /** Notification */


### PR DESCRIPTION
This prop was added in V7.12:  https://mantine.dev/changelog/7-12-0/

Here's a sample app for the docs:

See it live:  https://py.cafe/amward/dmc-PR-419-Notification-Position

```python
from dash import Dash, html, callback, Output, Input, _dash_renderer
import dash_mantine_components as dmc
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center']

app.layout = dmc.MantineProvider(html.Div(
    [
        dmc.NotificationProvider(withinPortal=True),
        dmc.Center(
            dmc.Select(label="Notification Position", data=positions, value="top-right", id="notify-position", w=400),
            style={"height": 300, "width": "100%"},
        ),
        html.Div(id="notify-container")
    ]
))

@callback(
    Output("notify-container", "children"),
    Input("notify-position", "value"),
    prevent_initial_call=True,
)
def notify(value):
    return dmc.Notification(
            title=f"Notification {value}",
            autoClose=False,
            action="show",
            message="Hello World",
            position=value
        )


if __name__ == "__main__":
    app.run(debug=True)


```