### PR TITLE
Fix `closeOnClickOutside` for the Popover component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# Unreleased
+
+### Fixed
+- Fixed closing of Popovers when clicking outside. #423 by @magicmq
+
 # 0.15.0
 
 ### Changed

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -15,7 +15,7 @@ const Popover = (props: Props) => {
                 (loading_state && loading_state.is_loading) || undefined
             }
             opened={opened}
-            onClose={() => setProps({ opened: false })}
+            onChange={(_opened) => !_opened && setProps({ opened: false })}
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 interface Props extends PopoverProps, DashBaseProps {}
 
-/** Popover Component */
+/** The Popover component can be used to display additional content in a dropdown element, triggered by a user interaction with a target element. */
 const Popover = (props: Props) => {
     const { children, opened, setProps, loading_state, ...others } = props;
 

--- a/tests/test_popover.py
+++ b/tests/test_popover.py
@@ -10,6 +10,7 @@ def test_001po_popover(dash_duo):
     app.layout = dmc.MantineProvider(
         html.Div(
             [
+                html.Div("Click Outside", id="click-outside", style={"background": "grey"}),
                 dmc.Popover(
                     [
                         dmc.PopoverTarget(dmc.Button("Toggle Popover", id="btn")),
@@ -32,13 +33,30 @@ def test_001po_popover(dash_duo):
     # Wait for the app to load
     dash_duo.wait_for_text_to_equal("#output", "False")
 
+    # Open Popover
     popover_btn = dash_duo.find_element("#btn")
     popover_btn.click()
 
-    # Verify the output
+    # Verify the Popover opens when clicking the target
     dash_duo.wait_for_text_to_equal("#output", "True")
 
+    # Close Popover
     popover_btn.click()
+
+    # Verify the Popover closes when clicking the target
+    dash_duo.wait_for_text_to_equal("#output", "False")
+
+    #Open Popover
+    popover_btn.click()
+
+    # Verify the Popover is open
+    dash_duo.wait_for_text_to_equal("#output", "True")
+
+    # Click outside
+    click_outside = dash_duo.find_element("#click-outside")
+    click_outside.click()
+
+    # Verify the Popover closes when clicking outside
     dash_duo.wait_for_text_to_equal("#output", "False")
 
     assert dash_duo.get_logs() == []


### PR DESCRIPTION
### Summary

Beginning with Mantine version 7.13.4, the behavior of the `onClose` prop for the Popover component was changed in relation to other bug fixes within the project. Previously, the `onClose` prop was called when a user action triggered the dropdown (which meant `onClose` could be used to control the state of the popover). However, `onClose` is now called **when the Popover actually closes**, not when a trigger occurs. Therefore, `onClose` is no longer a viable method for controlling the Popover's state.

The Mantine developers recommend using the `onChange` prop instead to control the Popover's state (https://github.com/mantinedev/mantine/issues/7019). As such, this PR updates the Popover component to utilize the `onChange` method for closing the Popover rather than `onClose`.

This PR should also fix `closeOnEscape`, as this too previously relied upon the `onClose` prop to function correctly.

Closes #420.

### Changes
- The Popover component now utilizes the `onChange` prop to control its state.
- Added a description to the Popover component (work towards #421).
- Updated the popover test to include testing for closure on clicking outside.
- Updated the CHANGELOG.md.

### Example
```python
from dash import Dash, html, _dash_renderer
import dash_mantine_components as dmc

_dash_renderer._set_react_version("18.2.0")

app = Dash()

app.layout = dmc.MantineProvider(dmc.Box(
    [
        dmc.Popover(
            [
                dmc.PopoverTarget(
                    dmc.Button('Toggle Popover')
                ),
                dmc.PopoverDropdown(
                    dmc.Stack(
                        [
                            dmc.Title('A Popover', size='lg', order=4, c='black'),
                            dmc.Text('Popover Text')
                        ],
                        gap='xs'
                    )
                )
            ]
        )
    ],
    m=10
))

app.run_server(debug=True)
```

The fix is tested working with the above example, but I have not run other testing with `pytest` so I am not sure if the change is 100% passing. Let me know if you have any feedback or if you would like me to run additional testing.