### PR TITLE
add mantine_light and mantine_dark plotly figure templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 
 - Added `disabled` prop to `Radio`  #425  by @namakshenas
-- Added the `create_mantine_figure_templates()` function which creates Mantine-styled Plotly figure templates for
+- Added the `add_figure_templates()` function which creates Mantine-styled Plotly figure templates for
 both light and dark modes using the default Mantine theme.  It registers the templates with plotly.io.templates as
 "mantine_light" and "mantine_dark", and optionally sets one of the themes as a default. #431 by @AnnMarie
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Added
 
 - Added `disabled` prop to `Radio`  #425  by @namakshenas
+- Added the `create_mantine_figure_templates()` function which creates Mantine-styled Plotly figure templates for
+both light and dark modes using the default Mantine theme.  It registers the templates with plotly.io.templates as
+"mantine_light" and "mantine_dark", and optionally sets one of the themes as a default. #431 by @AnnMarie
+
 
 ### Fixed
 - Fixed closing of Popovers when clicking outside. #423 by @magicmq

--- a/dash_mantine_components/__init__.py
+++ b/dash_mantine_components/__init__.py
@@ -12,7 +12,7 @@ from . import styles
 from ._imports_ import *
 from ._imports_ import __all__
 from .theme import DEFAULT_THEME
-from .figure_templates import create_mantine_figure_templates
+from .figure_templates import add_figure_templates
 
 if not hasattr(_dash, "__plotly_dash") and not hasattr(_dash, "development"):
     print(
@@ -65,4 +65,4 @@ for _component in __all__:
     setattr(locals()[_component], "_css_dist", _css_dist)
 
 
-__all__ += [DEFAULT_THEME, styles, create_mantine_figure_templates]
+__all__ += [DEFAULT_THEME, styles, add_figure_templates]

--- a/dash_mantine_components/__init__.py
+++ b/dash_mantine_components/__init__.py
@@ -65,4 +65,4 @@ for _component in __all__:
     setattr(locals()[_component], "_css_dist", _css_dist)
 
 
-__all__ += [DEFAULT_THEME, styles]
+__all__ += [DEFAULT_THEME, styles, create_mantine_figure_templates]

--- a/dash_mantine_components/__init__.py
+++ b/dash_mantine_components/__init__.py
@@ -12,6 +12,7 @@ from . import styles
 from ._imports_ import *
 from ._imports_ import __all__
 from .theme import DEFAULT_THEME
+from .figure_templates import create_mantine_figure_templates
 
 if not hasattr(_dash, "__plotly_dash") and not hasattr(_dash, "development"):
     print(

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -4,7 +4,7 @@ import plotly.io as pio
 import copy
 
 
-def create_mantine_figure_templates(default=None):
+def add_figure_templates(default=None):
 
     """
     Create and register Plotly figure templates styled to match the Mantine default theme.

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -1,0 +1,94 @@
+import dash_mantine_components as dmc
+import plotly.graph_objects as go
+import plotly.io as pio
+import copy
+
+
+def create_mantine_figure_templates():
+    """
+    Create Mantine-styled Plotly templates for both light and dark modes.
+    registers templates with plotly.io.templates as "mantine_light" and "mantine_dark"
+    """
+
+    colors = dmc.DEFAULT_THEME["colors"]
+    font_family = dmc.DEFAULT_THEME["fontFamily"]
+    # pallet generated from https://www.learnui.design/tools/data-color-picker.html#palette
+    custom_colorscale = [
+        "#1864ab",  # blue[9]
+        "#7065b9",
+        "#af61b7",
+        "#e35ea5",
+        "#ff6587",
+        "#ff7c63",
+        "#ff9e3d",
+        "#fcc419",  # yellow[5]
+    ]
+
+    # Default theme configurations
+    default_themes = {
+        "light": {
+            "colorway": [
+                colors[color][6]
+                for color in ["blue", "red", "green", "violet", "orange", "cyan", "pink", "yellow"]
+            ],
+            "paper_bgcolor": "#f8f9fa",
+            "plot_bgcolor": "#ffffff",
+            "gridcolor": "#dee2e6",
+        },
+        "dark": {
+            "colorway": [
+                colors[color][8]
+                for color in ["blue", "red", "green", "violet", "orange", "cyan", "pink", "yellow"]
+            ],
+            "paper_bgcolor": "#1a1b1e",
+            "plot_bgcolor": "#25262b",
+            "gridcolor": "#343a40",
+        }
+    }
+
+    def make_template(name):
+        #Start with either a light or dark Plotly template
+        base = "plotly_white" if name == "light" else "plotly_dark"
+        template = copy.deepcopy(pio.templates[base])
+
+        layout = template.layout
+        theme_config = default_themes[name]
+
+        # Apply theme settings
+        layout.colorway = theme_config["colorway"]
+        layout.colorscale.sequential = custom_colorscale
+        layout.piecolorway = theme_config["colorway"]
+        layout.paper_bgcolor = theme_config["paper_bgcolor"]
+        layout.plot_bgcolor = theme_config["plot_bgcolor"]
+        layout.font.family = font_family
+
+        # Grid settings
+        for axis in (layout.xaxis, layout.yaxis):
+            axis.gridcolor = theme_config["gridcolor"]
+            axis.gridwidth = 0.5
+            axis.zerolinecolor = theme_config["gridcolor"]
+
+        # Geo settings
+        layout.geo.bgcolor = theme_config["plot_bgcolor"]
+        layout.geo.lakecolor = theme_config["plot_bgcolor"]
+        layout.geo.landcolor = theme_config["plot_bgcolor"]
+
+        # Hover label settings
+        layout.hoverlabel.font.family = font_family
+
+        # Scatter plot settings
+        template.data.scatter = (go.Scatter(marker_line_color=theme_config["plot_bgcolor"]),)
+        template.data.scattergl = (go.Scattergl(marker_line_color=theme_config["plot_bgcolor"]),)
+
+        return template
+
+
+    # #register templates
+    pio.templates["mantine_light"] = make_template("light")
+    pio.templates["mantine_dark"] = make_template("dark")
+
+    return None
+
+
+# Create and register templates
+create_mantine_figure_templates()

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -106,5 +106,7 @@ def create_mantine_figure_templates(default=None):
     # set the default
     if default in ["mantine_light", "mantine_dark"]:
         pio.templates.default = default
+    elif default:
+        raise ValueError(f"unrecognized {default=}, allowed values are 'mantine_light' and 'mantine_dark'")
 
     return None

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -47,7 +47,7 @@ def add_figure_templates(default=None):
                 colors[color][6]
                 for color in ["blue", "red", "green", "violet", "orange", "cyan", "pink", "yellow"]
             ],
-            "paper_bgcolor": "#f8f9fa",
+            "paper_bgcolor":  "#ffffff",  # mantine background color
             "plot_bgcolor": "#ffffff",
             "gridcolor": "#dee2e6",
         },
@@ -56,8 +56,8 @@ def add_figure_templates(default=None):
                 colors[color][8]
                 for color in ["blue", "red", "green", "violet", "orange", "cyan", "pink", "yellow"]
             ],
-            "paper_bgcolor": "#1a1b1e",
-            "plot_bgcolor": "#25262b",
+            "paper_bgcolor":  colors["dark"][7], # mantine background color
+            "plot_bgcolor":  colors["dark"][7],
             "gridcolor": "#343a40",
         }
     }

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -1,4 +1,4 @@
-import dash_mantine_components as dmc
+from .theme import DEFAULT_THEME
 import plotly.graph_objects as go
 import plotly.io as pio
 import copy
@@ -10,8 +10,8 @@ def create_mantine_figure_templates():
     registers templates with plotly.io.templates as "mantine_light" and "mantine_dark"
     """
 
-    colors = dmc.DEFAULT_THEME["colors"]
-    font_family = dmc.DEFAULT_THEME["fontFamily"]
+    colors = DEFAULT_THEME["colors"]
+    font_family = DEFAULT_THEME["fontFamily"]
     # pallet generated from https://www.learnui.design/tools/data-color-picker.html#palette
     custom_colorscale = [
         "#1864ab",  # blue[9]

--- a/dash_mantine_components/figure_templates.py
+++ b/dash_mantine_components/figure_templates.py
@@ -4,10 +4,26 @@ import plotly.io as pio
 import copy
 
 
-def create_mantine_figure_templates():
+def create_mantine_figure_templates(default=None):
+
     """
-    Create Mantine-styled Plotly templates for both light and dark modes.
-    registers templates with plotly.io.templates as "mantine_light" and "mantine_dark"
+    Create and register Plotly figure templates styled to match the Mantine default theme.
+
+    This function generates two custom Plotly templates:
+    - "mantine_light" for light mode
+    - "mantine_dark" for dark mode
+
+    Templates are registered with `plotly.io.templates`, allowing you to apply them to Plotly figures
+    using the template names "mantine_light" or "mantine_dark". These templates include Mantine-inspired
+    color palettes, background colors, and other layout customizations.
+
+    Parameters:
+    - default (str): The default template to apply globally. Must be either "mantine_light" or "mantine_dark".
+                      If not set, the default Plotly template remains unchanged.
+
+    Returns:
+    - None: The templates are registered and optionally set as the default, but no value is returned.
+
     """
 
     colors = DEFAULT_THEME["colors"]
@@ -87,8 +103,8 @@ def create_mantine_figure_templates():
     pio.templates["mantine_light"] = make_template("light")
     pio.templates["mantine_dark"] = make_template("dark")
 
+    # set the default
+    if default in ["mantine_light", "mantine_dark"]:
+        pio.templates.default = default
+
     return None
-
-
-# Create and register templates
-create_mantine_figure_templates()


### PR DESCRIPTION

This PR adds the `create_mantine_figure_templates()` function which creates Mantine-styled Plotly figure templates for both light and dark modes using the default Mantine theme.  It registers the templates with plotly.io.templates as "mantine_light" and "mantine_dark", and optionally sets one of the themes as a default.

The templates can be used in an app just like any built-in plotly template, for example:

```
px.histogram(dff, x='lifeExp', title='2007 Distribution of Life Expectancy', template="mantine_dark")
```

Here is a sample app hosted on PyCafe: https://py.cafe/amward/mantine-themed-plotly-figure-templates2

![image](https://github.com/user-attachments/assets/d277735f-e8bb-4311-acfa-5f2ba939ebf2)


![image](https://github.com/user-attachments/assets/775a22fb-02cc-4e2c-af82-af8494acb656)
