### PR TITLE
enable searchValue to be updated in callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ both light and dark modes using the default Mantine theme.  It registers the tem
 
 ### Fixed
 - Fixed closing of Popovers when clicking outside. #423 by @magicmq
+- Enabled `searchValue` in the `MultiSelect` component to be updated in a callback #441 by @AnnMarieW
 
 
 # 0.15.0

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -58,14 +58,12 @@ const MultiSelect = (props: Props) => {
         n_submit,
         n_blur,
         data,
-        searchValue,
         value,
         ...others
     } = props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
-    const [searchVal, setSearchVal] = useState(searchValue);
     const { ref, focused } = useFocusWithin();
 
     const debounceValue = typeof debounce === "number" ? debounce : 0;
@@ -82,12 +80,6 @@ const MultiSelect = (props: Props) => {
             setProps({ value: debounced });
         }
     }, [debounced]);
-
-    useDidUpdate(() => {
-        if (searchValue !== searchVal) {
-            setSearchVal(searchValue);
-        }
-    }, [searchValue]);
 
     const handleKeyDown = (ev) => {
         if (ev.key === "Enter") {
@@ -134,7 +126,6 @@ const MultiSelect = (props: Props) => {
                 data={options}
                 onChange={setSelected}
                 value={selected}
-                searchValue={searchVal}
                 onSearchChange={handleSearchChange}
                 {...others}
             />

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -106,7 +106,6 @@ const MultiSelect = (props: Props) => {
     };
 
     const handleSearchChange = (newSearchVal) => {
-        setSearchVal(newSearchVal);
         setProps({ searchValue: newSearchVal });
     };
 

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -66,23 +66,28 @@ const MultiSelect = (props: Props) => {
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
     const [searchVal, setSearchVal] = useState(searchValue);
-    const { ref, focused } = useFocusWithin()
+    const { ref, focused } = useFocusWithin();
 
-    const debounceValue = typeof debounce === 'number' ? debounce : 0;
+    const debounceValue = typeof debounce === "number" ? debounce : 0;
     const [debounced] = useDebouncedValue(selected, debounceValue);
 
     useDidUpdate(() => {
-        if (typeof debounce === 'number' || debounce === false) {
+        if (typeof debounce === "number" || debounce === false) {
             setProps({ value: debounced });
         }
 
         // Update the value prop if an item is removed by clicking the "x" on the pill,
         // even if the input is not focused at the time
         if (!focused && debounce === true) {
-            setProps({ value: debounced})
+            setProps({ value: debounced });
         }
     }, [debounced]);
 
+    useDidUpdate(() => {
+        if (searchValue !== searchVal) {
+            setSearchVal(searchValue);
+        }
+    }, [searchValue]);
 
     const handleKeyDown = (ev) => {
         if (ev.key === "Enter") {
@@ -96,8 +101,13 @@ const MultiSelect = (props: Props) => {
     const handleBlur = () => {
         setProps({
             n_blur: n_blur + 1,
-            ...(debounce === true && { value: selected })
+            ...(debounce === true && { value: selected }),
         });
+    };
+
+    const handleSearchChange = (newSearchVal) => {
+        setSearchVal(newSearchVal);
+        setProps({ searchValue: newSearchVal });
     };
 
     useDidUpdate(() => {
@@ -114,10 +124,6 @@ const MultiSelect = (props: Props) => {
         setProps({ data: options });
     }, [options]);
 
-    useDidUpdate(() => {
-        setProps({ searchValue: searchVal });
-    }, [searchVal]);
-
     return (
         <div ref={ref}>
             <MantineMultiSelect
@@ -130,7 +136,7 @@ const MultiSelect = (props: Props) => {
                 onChange={setSelected}
                 value={selected}
                 searchValue={searchVal}
-                onSearchChange={setSearchVal}
+                onSearchChange={handleSearchChange}
                 {...others}
             />
         </div>

--- a/tests/combobox/test_multi_select.py
+++ b/tests/combobox/test_multi_select.py
@@ -57,7 +57,7 @@ def test_001mu_multi_select(dash_duo):
 
     assert dash_duo.get_logs() == []
 
-# ensure both data and value can be updated in a callback
+# ensure  data and value and SearchValue can be updated in a callback
 def test_002mu_multi_select(dash_duo):
 
     app = Dash(__name__)
@@ -75,26 +75,28 @@ def test_002mu_multi_select(dash_duo):
     @app.callback(
         Output("select", "data"),
         Output("select", "value"),
+        Output("select", "searchValue"),
         Input("update-select", "n_clicks"),
         prevent_initial_call=True
     )
     def update_select(_):
-        return ["a", "b", "c"], ["b"]
+        return ["a", "b", "c"], ["b"], "a"
 
     @app.callback(
         Output("out", "children"),
-        Input("select", "value")
+        Input("select", "value"),
+        Input("select", "searchValue")
     )
-    def update(v):
-        return str(v)
+    def update(val, search):
+        return f"{val=} {search=}"
 
 
     dash_duo.start_server(app)
     # Wait for the app to load
-    dash_duo.wait_for_text_to_equal("#out", "None" )
+    dash_duo.wait_for_text_to_equal("#out", "val=None search=None" )
 
     dash_duo.find_element("#update-select").click()
 
-    dash_duo.wait_for_text_to_equal("#out", "['b']")
+    dash_duo.wait_for_text_to_equal("#out", "val=['b'] search='a'")
 
     assert dash_duo.get_logs() == []


### PR DESCRIPTION
This enables a [feature request posted on the forum](https://community.plotly.com/t/issue-with-search-text-reset-in-dash-mantine-components-multiselect/89133) to make it possible to keep the search value after an item is selected  in MultiSelect.

The dmc.MultiSelect automatically clears the search value when an item is selected, but it should be possible to restore it in a callback.  

This PR fixes a bug where it was not possible to update the `searchValue` in a callback.


Here is a sample use case:

https://py.cafe/amward/dmc-pr-441-update-searchValue-in-callback

```python

import dash_mantine_components as dmc
from dash import Dash, _dash_renderer, html, dcc, Input, Output, State, callback
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

component = dmc.MultiSelect(
    label="Pick your favorite libraries",
    data=["Pandas", "NumPy", "TensorFlow", "PyTorch"],
    searchable=True,
    w=400,
    id="select",
)


app.layout = dmc.MantineProvider([
    dcc.Store(id="search"),
    html.Div(id="out"),
    component
])

@callback(
    Output("search", "data"),
    Input("select", "searchValue")
)
def update(searchValue):
    return searchValue


@callback(
    Output("out", "children"),
    Output("select", "searchValue"),
    Input("select", "value"),
    State("search", "data")
)
def update(val,search):
    return f"You selected {val}", search

```

