### PR TITLE
added ColorSchemeSwitch

### DIFF
--- a/src/ts/components/styles/ColorSchemeSwitch.tsx
+++ b/src/ts/components/styles/ColorSchemeSwitch.tsx
@@ -1,0 +1,78 @@
+import {
+    useComputedColorScheme,
+    useMantineColorScheme,
+    ActionIcon as MantineActionIcon,
+} from "@mantine/core";
+import { ActionIconProps } from "props/actionicon";
+import { DashBaseProps } from "props/dash";
+import React, { useEffect } from "react";
+
+interface Props extends ActionIconProps, DashBaseProps {
+    /** An integer that represents the number of times that this element has been clicked on */
+    n_clicks?: number;
+    /** Current color schem  "light" | "dark" */
+    color_scheme?: "light" | "dark";
+    /** The icon to display when the application is in light mode. This icon represents the action to switch to dark mode.  Default: moon icon */
+    iconForLightMode: React.ReactNode;
+    /** The icon to display when the application is in dark mode. This icon represents the action to switch to light mode.  Default: sun icon */
+    iconForDarkMode: React.ReactNode;
+}
+
+/** A toggle switch component for changing between light and dark color schemes. */
+const ColorSchemeSwitch = (props: Props) => {
+    const {
+        children,
+        setProps,
+        loading_state,
+        disabled,
+        n_clicks = 0,
+        variant = "transparent",
+        iconForDarkMode,
+        iconForLightMode,
+        color_scheme,
+        ...others
+    } = props;
+
+    const { setColorScheme } = useMantineColorScheme();
+    const computedColorScheme = useComputedColorScheme("light", {
+        getInitialValueInEffect: true,
+    });
+
+    useEffect(() => {
+        if (color_scheme && color_scheme !== computedColorScheme) {
+            setColorScheme(color_scheme);
+        }
+    }, [color_scheme]);
+
+    const toggle = () => {
+        if (disabled) return;
+
+        const newColorScheme =
+            computedColorScheme === "light" ? "dark" : "light";
+
+        setColorScheme(newColorScheme);
+        setProps({
+            n_clicks: n_clicks + 1,
+            color_scheme: newColorScheme,
+        });
+    };
+
+    return (
+        <MantineActionIcon
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            disabled={disabled}
+            onClick={toggle}
+            variant={variant}
+            aria-label="Toggle color scheme"
+            {...others}
+        >
+            {computedColorScheme === "light"
+                ? iconForLightMode
+                : iconForDarkMode}
+        </MantineActionIcon>
+    );
+};
+
+export default ColorSchemeSwitch;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -151,6 +151,7 @@ import NavigationProgress from "./components/extensions/nprogress/NavigationProg
 import NavigationProgressProvider from "./components/extensions/nprogress/NavigationProgressProvider";
 import MantineProvider from "./components/styles/MantineProvider";
 import ChipGroup from "./components/core/chip/ChipGroup";
+import ColorSchemeSwitch from "./components/styles/ColorSchemeSwitch";
 
 export {
     Accordion,
@@ -199,6 +200,7 @@ export {
     Collapse,
     ColorInput,
     ColorPicker,
+    ColorSchemeSwitch,
     CompositeChart,
     Container,
     DateInput,


### PR DESCRIPTION
 A toggle switch component for changing between light and dark color schemes.
  
 The `ColorSchemeSwitch` allows users to toggle between light and dark modes
  with a single click. No callbacks required!  It uses icons to indicate the available action: the icon
  displayed represents the mode the user can switch to (e.g., a moon icon for
  toggling to dark mode and a sun icon for toggling to light mode).
  
 Behavior:
  - Automatically syncs with the application's color scheme using Mantine's context.
  - Updates the color scheme via [`setColorScheme`](https://mantine.dev/theming/color-schemes/) when toggled or when `color_scheme` changes.
     -- The color scheme selected by the is persistent     
  - Displays appropriate icons for toggling actions

```
import dash_mantine_components as dmc
from dash import Dash, _dash_renderer
_dash_renderer._set_react_version("18.2.0")
from dash_iconify import DashIconify

app = Dash(external_stylesheets=dmc.styles.ALL)


component = dmc.ColorSchemeSwitch(
    iconForLightMode=DashIconify(icon="radix-icons:moon", width=25),
    iconForDarkMode=DashIconify( icon="radix-icons:sun",width=25),
    color="yellow",
)

app.layout = dmc.MantineProvider(
    dmc.Group([
        dmc.Title("ColorSchemeSwitch Demo"),
        component
    ], p="lg"),
)

if __name__ == "__main__":
    app.run(debug=True)


```

![dmc-ColorSchemeSwitch](https://github.com/user-attachments/assets/d47ba97a-f4b7-43f8-a567-789dfecb55d0)


 