### PR TITLE
Update for Dash 3.0:  Remove dashprivate props, change loading state

### DIFF
--- a/src/ts/components/charts/AreaChart.tsx
+++ b/src/ts/components/charts/AreaChart.tsx
@@ -65,7 +65,7 @@ interface Props
 
 /** AreaChart */
 const AreaChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, areaChartProps, activeDotProps, areaProps, ...others } = props;
+    const { setProps, clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, areaChartProps, activeDotProps, areaProps, ...others } = props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
     const shouldHighlight = highlightHover && highlightedArea !== null;
@@ -151,9 +151,12 @@ const AreaChart = (props: Props) => {
 
     const newProps = { ...areaChartProps, onClick, onMouseOver };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
       <MantineAreaChart
-        data-dash-is-loading={(loading_state && loading_state.is_loading) || undefined}
+        data-dash-is-loading={loading || undefined}
         areaChartProps={newProps}
         series={series}
         activeDotProps={{

--- a/src/ts/components/charts/AreaChart.tsx
+++ b/src/ts/components/charts/AreaChart.tsx
@@ -65,7 +65,7 @@ interface Props
 
 /** AreaChart */
 const AreaChart = (props: Props) => {
-    const { setProps, clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, areaChartProps, activeDotProps, areaProps, ...others } = props;
+    const { setProps, clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover = false, areaChartProps, activeDotProps, areaProps, ...others } = props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
     const shouldHighlight = highlightHover && highlightedArea !== null;
@@ -170,9 +170,5 @@ const AreaChart = (props: Props) => {
       />
     );
 }
-
-AreaChart.defaultProps = {
-    highlightHover: false,
-};
 
 export default AreaChart;

--- a/src/ts/components/charts/BarChart.tsx
+++ b/src/ts/components/charts/BarChart.tsx
@@ -57,7 +57,7 @@ interface Props
 const BarChart = (props: Props) => {
     const {
         setProps,  clickData, hoverData, barChartProps, clickSeriesName, hoverSeriesName, barProps,
-        highlightHover, ...others } =  props;
+        highlightHover = false, withBarValueLabel= false, ...others } =  props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
     const shouldHighlight = highlightHover && highlightedArea !== null;
@@ -140,13 +140,6 @@ const BarChart = (props: Props) => {
 
     );
 };
-
-
-BarChart.defaultProps = {
-    withBarValueLabel: false,
-    highlightHover: false,
-};
-
 
 
 export default BarChart;

--- a/src/ts/components/charts/BarChart.tsx
+++ b/src/ts/components/charts/BarChart.tsx
@@ -56,7 +56,7 @@ interface Props
 /** BarChart */
 const BarChart = (props: Props) => {
     const {
-        setProps, loading_state, clickData, hoverData, barChartProps, clickSeriesName, hoverSeriesName, barProps,
+        setProps,  clickData, hoverData, barChartProps, clickSeriesName, hoverSeriesName, barProps,
         highlightHover, ...others } =  props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
@@ -127,11 +127,12 @@ const BarChart = (props: Props) => {
 
     const newProps = { ...barChartProps, onClick, onMouseOver };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineBarChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             barChartProps={newProps}
             barProps={barPropsFunction}
             {...others}

--- a/src/ts/components/charts/BarChart.tsx
+++ b/src/ts/components/charts/BarChart.tsx
@@ -135,6 +135,7 @@ const BarChart = (props: Props) => {
             data-dash-is-loading={loading || undefined}
             barChartProps={newProps}
             barProps={barPropsFunction}
+            withBarValueLabel={withBarValueLabel}
             {...others}
         />
 

--- a/src/ts/components/charts/BubbleChart.tsx
+++ b/src/ts/components/charts/BubbleChart.tsx
@@ -49,7 +49,7 @@ interface Props
 
 /** ScatterChart */
 const BubbleChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, scatterProps, ...others } =
+    const { setProps,  clickData, hoverData, scatterProps, ...others } =
         props;
 
     const onClick = (ev) => {
@@ -66,11 +66,12 @@ const BubbleChart = (props: Props) => {
 
     const newProps = { ...scatterProps, onClick, onMouseOver};
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineBubbleChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             scatterProps={newProps}
             {...others}
         />

--- a/src/ts/components/charts/CompositeChart.tsx
+++ b/src/ts/components/charts/CompositeChart.tsx
@@ -188,6 +188,8 @@ const CompositeChart = (props: Props) => {
                 onMouseOver: handleDotHover,
                 onMouseOut: handleHoverEnd,
             }}
+            withPointLabels={withPointLabels}
+            withBarValueLabel={withBarValueLabel}
             {...others}
         />
     );

--- a/src/ts/components/charts/CompositeChart.tsx
+++ b/src/ts/components/charts/CompositeChart.tsx
@@ -64,7 +64,21 @@ interface Props
 
 /** CompositeChart */
 const CompositeChart = (props: Props) => {
-    const { setProps,  clickData, hoverData, highlightHover, hoverSeriesName, clickSeriesName, composedChartProps, barProps, lineProps, areaProps, activeDotProps, ...others } =
+    const {
+        setProps,
+        clickData,
+        hoverData,
+        highlightHover = false,
+        hoverSeriesName,
+        clickSeriesName,
+        composedChartProps,
+        barProps,
+        lineProps,
+        areaProps,
+        activeDotProps,
+        withPointLabels = false,
+        withBarValueLabel = false,
+        ...others } =
         props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
@@ -179,10 +193,5 @@ const CompositeChart = (props: Props) => {
     );
 };
 
-CompositeChart.defaultProps = {
-    withPointLabels: false,
-    withBarValueLabel: false,
-    highlightHover: false
-};
 
 export default CompositeChart;

--- a/src/ts/components/charts/CompositeChart.tsx
+++ b/src/ts/components/charts/CompositeChart.tsx
@@ -64,7 +64,7 @@ interface Props
 
 /** CompositeChart */
 const CompositeChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, highlightHover, hoverSeriesName, clickSeriesName, composedChartProps, barProps, lineProps, areaProps, activeDotProps, ...others } =
+    const { setProps,  clickData, hoverData, highlightHover, hoverSeriesName, clickSeriesName, composedChartProps, barProps, lineProps, areaProps, activeDotProps, ...others } =
         props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
@@ -157,11 +157,13 @@ const CompositeChart = (props: Props) => {
 
     const newProps = { ...composedChartProps, onClick, onMouseOver};
 
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineCompositeChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             composedChartProps={newProps}
             barProps={(item) => propsFunction(item, 'bar')}   // Pass the chart type as 'bar'
             lineProps={(item) => propsFunction(item, 'line')}  // Pass the chart type as 'line'

--- a/src/ts/components/charts/DonutChart.tsx
+++ b/src/ts/components/charts/DonutChart.tsx
@@ -58,7 +58,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** DonutChart */
 const DonutChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, clickSeriesName, hoverSeriesName, pieProps, ...others } = props;
+    const { setProps,  clickData, hoverData, clickSeriesName, hoverSeriesName, pieProps, ...others } = props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -82,11 +82,12 @@ const DonutChart = (props: Props) => {
 
     const newProps = { ...pieProps, onClick, onMouseOver};
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineDonutChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             pieProps={newProps}
             {...others}
         />

--- a/src/ts/components/charts/LineChart.tsx
+++ b/src/ts/components/charts/LineChart.tsx
@@ -62,7 +62,7 @@ interface Props
 
 /** Mantine-themed line chart built on top of the Recharts library, */
 const LineChart = (props: Props) => {
-    const { setProps,  clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, lineChartProps, activeDotProps, lineProps, ...others } = props;
+    const { setProps,  clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover = false, lineChartProps, activeDotProps, lineProps, ...others } = props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
     const shouldHighlight = highlightHover && highlightedArea !== null;
@@ -165,10 +165,6 @@ const LineChart = (props: Props) => {
             {...others}
         />
     );
-};
-
-LineChart.defaultProps = {
-    highlightHover: false,
 };
 
 export default LineChart;

--- a/src/ts/components/charts/LineChart.tsx
+++ b/src/ts/components/charts/LineChart.tsx
@@ -62,7 +62,7 @@ interface Props
 
 /** Mantine-themed line chart built on top of the Recharts library, */
 const LineChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, lineChartProps, activeDotProps, lineProps, ...others } = props;
+    const { setProps,  clickData, hoverData, clickSeriesName, hoverSeriesName, series, highlightHover, lineChartProps, activeDotProps, lineProps, ...others } = props;
 
     const [highlightedArea, setHighlightedArea] = useState(null);
     const shouldHighlight = highlightHover && highlightedArea !== null;
@@ -147,11 +147,12 @@ const LineChart = (props: Props) => {
 
     const newProps = { ...lineChartProps, onClick, onMouseOver };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineLineChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             lineChartProps={newProps}
             series={series}
             activeDotProps={{

--- a/src/ts/components/charts/PieChart.tsx
+++ b/src/ts/components/charts/PieChart.tsx
@@ -58,7 +58,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** PieChart */
 const PieChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData,  clickSeriesName, hoverSeriesName, pieProps, ...others } = props;
+    const { setProps,  clickData, hoverData,  clickSeriesName, hoverSeriesName, pieProps, ...others } = props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -82,11 +82,12 @@ const PieChart = (props: Props) => {
 
     const newProps = { ...pieProps, onClick, onMouseOver};
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantinePieChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             pieProps={newProps}
             {...others}
         />

--- a/src/ts/components/charts/RadarChart.tsx
+++ b/src/ts/components/charts/RadarChart.tsx
@@ -46,8 +46,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** RadarChart */
 const RadarChart = (props: Props) => {
-    const { setProps, loading_state, clickData, radarChartProps, ...others } =
-        props;
+    const { setProps,  clickData, radarChartProps, ...others } =props;
 
     const onClick = (ev) => {
         if (isEventValid(ev)) {
@@ -57,11 +56,12 @@ const RadarChart = (props: Props) => {
 
     const newProps = { ...radarChartProps, onClick };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineRadarChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             radarChartProps={newProps}
             {...others}
         />

--- a/src/ts/components/charts/RadarChart.tsx
+++ b/src/ts/components/charts/RadarChart.tsx
@@ -68,6 +68,4 @@ const RadarChart = (props: Props) => {
     );
 };
 
-RadarChart.defaultProps = {};
-
 export default RadarChart;

--- a/src/ts/components/charts/ScatterChart.tsx
+++ b/src/ts/components/charts/ScatterChart.tsx
@@ -47,7 +47,7 @@ interface Props
 
 /** ScatterChart */
 const ScatterChart = (props: Props) => {
-    const { setProps, loading_state, clickData, hoverData, clickSeriesName, hoverSeriesName, scatterProps, ...others } =
+    const { setProps,  clickData, hoverData, clickSeriesName, hoverSeriesName, scatterProps, ...others } =
         props;
 
     const onClick = (ev) => {
@@ -72,11 +72,12 @@ const ScatterChart = (props: Props) => {
 
     const newProps = { ...scatterProps, onClick, onMouseOver};
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineScatterChart
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             scatterProps={newProps}
             {...others}
         />

--- a/src/ts/components/charts/ScatterChart.tsx
+++ b/src/ts/components/charts/ScatterChart.tsx
@@ -84,6 +84,4 @@ const ScatterChart = (props: Props) => {
     );
 };
 
-ScatterChart.defaultProps = {};
-
 export default ScatterChart;

--- a/src/ts/components/charts/Sparkline.tsx
+++ b/src/ts/components/charts/Sparkline.tsx
@@ -32,13 +32,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Sparkline */
 const Sparkline = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps,  ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineSparkline
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/charts/Sparkline.tsx
+++ b/src/ts/components/charts/Sparkline.tsx
@@ -45,6 +45,4 @@ const Sparkline = (props: Props) => {
     );
 };
 
-Sparkline.defaultProps = {};
-
 export default Sparkline;

--- a/src/ts/components/core/Affix.tsx
+++ b/src/ts/components/core/Affix.tsx
@@ -30,6 +30,4 @@ const Affix = (props: Props) => {
     );
 };
 
-Affix.defaultProps = {};
-
 export default Affix;

--- a/src/ts/components/core/Affix.tsx
+++ b/src/ts/components/core/Affix.tsx
@@ -15,13 +15,14 @@ interface Props
 
 /** Affix */
 const Affix = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineAffix
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Alert.tsx
+++ b/src/ts/components/core/Alert.tsx
@@ -33,7 +33,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Alert */
 const Alert = (props: Props) => {
-    const { children, setProps, duration, hide, ...others } =
+    const { children, setProps, duration, hide = false, ...others } =
         props;
     const ref = useRef(null);
 
@@ -64,10 +64,6 @@ const Alert = (props: Props) => {
             {children}
         </MantineAlert>
     );
-};
-
-Alert.defaultProps = {
-    hide: false,
 };
 
 export default Alert;

--- a/src/ts/components/core/Alert.tsx
+++ b/src/ts/components/core/Alert.tsx
@@ -33,7 +33,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Alert */
 const Alert = (props: Props) => {
-    const { children, setProps, loading_state, duration, hide, ...others } =
+    const { children, setProps, duration, hide, ...others } =
         props;
     const ref = useRef(null);
 
@@ -52,13 +52,14 @@ const Alert = (props: Props) => {
         setProps({ hide: true });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return hide ? null : (
         <MantineAlert
             {...others}
             onClose={onClose}
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
         >
             {children}
         </MantineAlert>

--- a/src/ts/components/core/Anchor.tsx
+++ b/src/ts/components/core/Anchor.tsx
@@ -49,6 +49,4 @@ const Anchor = (props: Props) => {
     );
 };
 
-Anchor.defaultProps = {};
-
 export default Anchor;

--- a/src/ts/components/core/Anchor.tsx
+++ b/src/ts/components/core/Anchor.tsx
@@ -26,17 +26,17 @@ const Anchor = (props: Props) => {
         refresh,
         children,
         setProps,
-        loading_state,
         ...others
     } = props;
 
     const sanitizedHref = useMemo(() => sanitizeUrl(href), [href]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineAnchor
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                 onClick(ev, sanitizedHref, target, refresh)
             }

--- a/src/ts/components/core/AspectRatio.tsx
+++ b/src/ts/components/core/AspectRatio.tsx
@@ -13,13 +13,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AspectRatio */
 const AspectRatio = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineAspectRatio
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/AspectRatio.tsx
+++ b/src/ts/components/core/AspectRatio.tsx
@@ -28,6 +28,4 @@ const AspectRatio = (props: Props) => {
     );
 };
 
-AspectRatio.defaultProps = {};
-
 export default AspectRatio;

--- a/src/ts/components/core/Badge.tsx
+++ b/src/ts/components/core/Badge.tsx
@@ -35,13 +35,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Badge */
 const Badge = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineBadge
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Badge.tsx
+++ b/src/ts/components/core/Badge.tsx
@@ -49,6 +49,4 @@ const Badge = (props: Props) => {
     );
 };
 
-Badge.defaultProps = {};
-
 export default Badge;

--- a/src/ts/components/core/Blockquote.tsx
+++ b/src/ts/components/core/Blockquote.tsx
@@ -41,6 +41,4 @@ const Blockquote = (props: Props) => {
     );
 };
 
-Blockquote.defaultProps = {};
-
 export default Blockquote;

--- a/src/ts/components/core/Blockquote.tsx
+++ b/src/ts/components/core/Blockquote.tsx
@@ -26,13 +26,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Blockquote */
 const Blockquote = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps,  ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineBlockquote
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Box.tsx
+++ b/src/ts/components/core/Box.tsx
@@ -25,6 +25,4 @@ const Box = (props: Props) => {
     );
 };
 
-Box.defaultProps = {};
-
 export default Box;

--- a/src/ts/components/core/Box.tsx
+++ b/src/ts/components/core/Box.tsx
@@ -10,13 +10,14 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Box */
 const Box = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineBox
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Breadcrumbs.tsx
+++ b/src/ts/components/core/Breadcrumbs.tsx
@@ -18,13 +18,14 @@ export interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Breadcrumbs */
 const Breadcrumbs = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineBreadcrumbs
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Breadcrumbs.tsx
+++ b/src/ts/components/core/Breadcrumbs.tsx
@@ -33,6 +33,4 @@ const Breadcrumbs = (props: Props) => {
     );
 };
 
-Breadcrumbs.defaultProps = {};
-
 export default Breadcrumbs;

--- a/src/ts/components/core/Burger.tsx
+++ b/src/ts/components/core/Burger.tsx
@@ -31,7 +31,6 @@ interface Props
 const Burger = (props: Props) => {
     const {
         setProps,
-        loading_state,
         opened,
         persistence,
         persisted_props,
@@ -45,11 +44,12 @@ const Burger = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineBurger
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onClick={onClick}
             opened={opened}
             {...others}

--- a/src/ts/components/core/Burger.tsx
+++ b/src/ts/components/core/Burger.tsx
@@ -31,10 +31,10 @@ interface Props
 const Burger = (props: Props) => {
     const {
         setProps,
-        opened,
+        opened = false,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['opened'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -55,12 +55,6 @@ const Burger = (props: Props) => {
             {...others}
         />
     );
-};
-
-Burger.defaultProps = {
-    opened: false,
-    persisted_props: ["opened"],
-    persistence_type: "local",
 };
 
 export default Burger;

--- a/src/ts/components/core/Center.tsx
+++ b/src/ts/components/core/Center.tsx
@@ -26,6 +26,4 @@ const Center = (props: Props) => {
     );
 };
 
-Center.defaultProps = {};
-
 export default Center;

--- a/src/ts/components/core/Center.tsx
+++ b/src/ts/components/core/Center.tsx
@@ -11,13 +11,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Center */
 const Center = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineCenter
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Code.tsx
+++ b/src/ts/components/core/Code.tsx
@@ -30,6 +30,4 @@ const Code = (props: Props) => {
     );
 };
 
-Code.defaultProps = {};
-
 export default Code;

--- a/src/ts/components/core/Code.tsx
+++ b/src/ts/components/core/Code.tsx
@@ -15,13 +15,14 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Code */
 const Code = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
 
     return (
         <MantineCode
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Collapse.tsx
+++ b/src/ts/components/core/Collapse.tsx
@@ -18,12 +18,13 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Collapse */
 const Collapse = (props: Props) => {
-    const { setProps, loading_state, opened, ...others } = props;
+    const { setProps, opened, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineCollapse
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             in={opened}
             {...others}
         />

--- a/src/ts/components/core/Collapse.tsx
+++ b/src/ts/components/core/Collapse.tsx
@@ -18,7 +18,7 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Collapse */
 const Collapse = (props: Props) => {
-    const { setProps, opened, ...others } = props;
+    const { setProps, opened = false, ...others } = props;
     const ctx = (window as any).dash_component_api.useDashContext();
     const loading = ctx.useLoading();
 
@@ -30,7 +30,5 @@ const Collapse = (props: Props) => {
         />
     );
 };
-
-Collapse.defaultProps = { opened: false };
 
 export default Collapse;

--- a/src/ts/components/core/Container.tsx
+++ b/src/ts/components/core/Container.tsx
@@ -29,6 +29,4 @@ const Container = (props: Props) => {
     );
 };
 
-Container.defaultProps = {};
-
 export default Container;

--- a/src/ts/components/core/Container.tsx
+++ b/src/ts/components/core/Container.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Container */
 const Container = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineContainer
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Divider.tsx
+++ b/src/ts/components/core/Divider.tsx
@@ -23,7 +23,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Divider */
 const Divider = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
 
     return (
         <MantineDivider

--- a/src/ts/components/core/Divider.tsx
+++ b/src/ts/components/core/Divider.tsx
@@ -32,6 +32,4 @@ const Divider = (props: Props) => {
     );
 };
 
-Divider.defaultProps = {};
-
 export default Divider;

--- a/src/ts/components/core/Drawer.tsx
+++ b/src/ts/components/core/Drawer.tsx
@@ -33,7 +33,7 @@ interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
 
 /** Drawer */
 const Drawer = (props: Props) => {
-    const { setProps, opened, children, ...others } = props;
+    const { setProps, opened = false, children, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -59,7 +59,5 @@ const Drawer = (props: Props) => {
         </MantineDrawer>
     );
 };
-
-Drawer.defaultProps = { opened: false };
 
 export default Drawer;

--- a/src/ts/components/core/Drawer.tsx
+++ b/src/ts/components/core/Drawer.tsx
@@ -34,7 +34,7 @@ interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
 /** Drawer */
 const Drawer = (props: Props) => {
     const { setProps, opened = false, children, ...others } = props;
-    const [open, setOpen] = useState(opened);
+    const [open, setOpen] = useState(opened ?? false);
 
     useEffect(() => {
         setOpen(opened);
@@ -51,13 +51,16 @@ const Drawer = (props: Props) => {
     return (
         <MantineDrawer
             data-dash-is-loading={loading || undefined}
-            opened={open}
             onClose={onClose}
             {...others}
+            opened={open}
         >
             {children}
         </MantineDrawer>
     );
 };
+
+// this is the only way to prevent the error: TypeError: Required argument opened was not specified.
+Drawer.defaultProps = { opened: false };
 
 export default Drawer;

--- a/src/ts/components/core/Drawer.tsx
+++ b/src/ts/components/core/Drawer.tsx
@@ -33,7 +33,7 @@ interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
 
 /** Drawer */
 const Drawer = (props: Props) => {
-    const { setProps, loading_state, opened, children, ...others } = props;
+    const { setProps, opened, children, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -45,11 +45,12 @@ const Drawer = (props: Props) => {
         setProps({ opened: false });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineDrawer
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             opened={open}
             onClose={onClose}
             {...others}

--- a/src/ts/components/core/Fieldset.tsx
+++ b/src/ts/components/core/Fieldset.tsx
@@ -31,6 +31,4 @@ const Fieldset = (props: Props) => {
     );
 };
 
-Fieldset.defaultProps = {};
-
 export default Fieldset;

--- a/src/ts/components/core/Fieldset.tsx
+++ b/src/ts/components/core/Fieldset.tsx
@@ -17,13 +17,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Fieldset */
 const Fieldset = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineFieldset
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Flex.tsx
+++ b/src/ts/components/core/Flex.tsx
@@ -39,6 +39,4 @@ const Flex = (props: Props) => {
     );
 };
 
-Flex.defaultProps = {};
-
 export default Flex;

--- a/src/ts/components/core/Flex.tsx
+++ b/src/ts/components/core/Flex.tsx
@@ -25,13 +25,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Flex */
 const Flex = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineFlex
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Group.tsx
+++ b/src/ts/components/core/Group.tsx
@@ -38,6 +38,4 @@ const Group = (props: Props) => {
     );
 };
 
-Group.defaultProps = {};
-
 export default Group;

--- a/src/ts/components/core/Group.tsx
+++ b/src/ts/components/core/Group.tsx
@@ -23,13 +23,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Group */
 const Group = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineGroup
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Highlight.tsx
+++ b/src/ts/components/core/Highlight.tsx
@@ -31,6 +31,4 @@ const Highlight = (props: Props) => {
     );
 };
 
-Highlight.defaultProps = {};
-
 export default Highlight;

--- a/src/ts/components/core/Highlight.tsx
+++ b/src/ts/components/core/Highlight.tsx
@@ -16,13 +16,14 @@ interface Props extends DashBaseProps, TextProps {
 
 /** Highlight */
 const Highlight = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps,  ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineHighlight
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Indicator.tsx
+++ b/src/ts/components/core/Indicator.tsx
@@ -40,13 +40,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Indicator */
 const Indicator = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineIndicator
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}{" "}

--- a/src/ts/components/core/Indicator.tsx
+++ b/src/ts/components/core/Indicator.tsx
@@ -54,6 +54,4 @@ const Indicator = (props: Props) => {
     );
 };
 
-Indicator.defaultProps = {};
-
 export default Indicator;

--- a/src/ts/components/core/Kbd.tsx
+++ b/src/ts/components/core/Kbd.tsx
@@ -13,13 +13,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Kbd */
 const Kbd = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineKbd
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Kbd.tsx
+++ b/src/ts/components/core/Kbd.tsx
@@ -27,6 +27,4 @@ const Kbd = (props: Props) => {
     );
 };
 
-Kbd.defaultProps = {};
-
 export default Kbd;

--- a/src/ts/components/core/Loader.tsx
+++ b/src/ts/components/core/Loader.tsx
@@ -7,13 +7,13 @@ interface Props extends LoaderProps, DashBaseProps {}
 
 /** Loader */
 const Loader = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineLoader
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/Loader.tsx
+++ b/src/ts/components/core/Loader.tsx
@@ -19,6 +19,4 @@ const Loader = (props: Props) => {
     );
 };
 
-Loader.defaultProps = {};
-
 export default Loader;

--- a/src/ts/components/core/LoadingOverlay.tsx
+++ b/src/ts/components/core/LoadingOverlay.tsx
@@ -34,6 +34,4 @@ const LoadingOverlay = (props: Props) => {
     );
 };
 
-LoadingOverlay.defaultProps = {};
-
 export default LoadingOverlay;

--- a/src/ts/components/core/LoadingOverlay.tsx
+++ b/src/ts/components/core/LoadingOverlay.tsx
@@ -22,13 +22,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** LoadingOverlay */
 const LoadingOverlay = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineLoadingOverlay
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/Mark.tsx
+++ b/src/ts/components/core/Mark.tsx
@@ -13,13 +13,13 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Mark */
 const Mark = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineMark
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Mark.tsx
+++ b/src/ts/components/core/Mark.tsx
@@ -27,6 +27,4 @@ const Mark = (props: Props) => {
     );
 };
 
-Mark.defaultProps = {};
-
 export default Mark;

--- a/src/ts/components/core/Modal.tsx
+++ b/src/ts/components/core/Modal.tsx
@@ -35,4 +35,7 @@ const Modal = (props: Props) => {
     );
 };
 
+// this is the only way to prevent the error: TypeError: Required argument opened was not specified.
+Modal.defaultProps = { opened: false };
+
 export default Modal;

--- a/src/ts/components/core/Modal.tsx
+++ b/src/ts/components/core/Modal.tsx
@@ -8,7 +8,7 @@ interface Props extends ModalProps, StylesApiProps, DashBaseProps {}
 
 /** Modal */
 const Modal = (props: Props) => {
-    const { children, setProps, opened, ...others } = props;
+    const { children, setProps, opened = false, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -34,7 +34,5 @@ const Modal = (props: Props) => {
         </MantineModal>
     );
 };
-
-Modal.defaultProps = { opened: false };
 
 export default Modal;

--- a/src/ts/components/core/Modal.tsx
+++ b/src/ts/components/core/Modal.tsx
@@ -8,7 +8,7 @@ interface Props extends ModalProps, StylesApiProps, DashBaseProps {}
 
 /** Modal */
 const Modal = (props: Props) => {
-    const { children, setProps, loading_state, opened, ...others } = props;
+    const { children, setProps, opened, ...others } = props;
     const [open, setOpen] = useState(opened);
 
     useEffect(() => {
@@ -20,11 +20,12 @@ const Modal = (props: Props) => {
         setProps({ opened: false });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineModal
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             opened={open}
             onClose={onClose}
             {...others}

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -12,8 +12,7 @@ import { TargetProps, onClick } from "../../utils/anchor";
 interface Props
     extends BoxProps,
         StylesApiProps,
-        DashBaseProps,
-        PersistenceProps {
+        DashBaseProps  {
     /** Main link label */
     label?: React.ReactNode;
     /** Link description, displayed below the label */
@@ -57,11 +56,8 @@ const NavLink = (props: Props) => {
         href,
         target,
         refresh,
-        n_clicks,
+        n_clicks = 0,
         children,
-        persistence,
-        persisted_props,
-        persistence_type,
         setProps,
         ...others
     } = props;
@@ -110,12 +106,6 @@ const NavLink = (props: Props) => {
             </MantineNavLink>
         );
     }
-};
-
-NavLink.defaultProps = {
-    n_clicks: 0,
-    persisted_props: ["opened"],
-    persistence_type: "local",
 };
 
 export default NavLink;

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -63,7 +63,6 @@ const NavLink = (props: Props) => {
         persisted_props,
         persistence_type,
         setProps,
-        loading_state,
         ...others
     } = props;
 
@@ -79,12 +78,13 @@ const NavLink = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     if (href) {
         return (
             <MantineNavLink
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined}
                 component="a"
                 onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                     onClick(ev, href, target, refresh)

--- a/src/ts/components/core/NumberFormatter.tsx
+++ b/src/ts/components/core/NumberFormatter.tsx
@@ -37,6 +37,4 @@ const NumberFormatter = (props: Props) => {
     );
 };
 
-NumberFormatter.defaultProps = {};
-
 export default NumberFormatter;

--- a/src/ts/components/core/NumberFormatter.tsx
+++ b/src/ts/components/core/NumberFormatter.tsx
@@ -25,13 +25,13 @@ interface Props extends DashBaseProps {
 
 /** NumberFormatter */
 const NumberFormatter = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineNumberFormatter
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/Overlay.tsx
+++ b/src/ts/components/core/Overlay.tsx
@@ -20,6 +20,4 @@ const Overlay = (props: Props) => {
     );
 };
 
-Overlay.defaultProps = {};
-
 export default Overlay;

--- a/src/ts/components/core/Overlay.tsx
+++ b/src/ts/components/core/Overlay.tsx
@@ -7,13 +7,14 @@ interface Props extends OverlayProps, DashBaseProps {}
 
 /** Overlay */
 const Overlay = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineOverlay
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/Pagination.tsx
+++ b/src/ts/components/core/Pagination.tsx
@@ -47,8 +47,8 @@ const Pagination = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -65,11 +65,6 @@ const Pagination = (props: Props) => {
             onChange={onChange}
         />
     );
-};
-
-Pagination.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default Pagination;

--- a/src/ts/components/core/Pagination.tsx
+++ b/src/ts/components/core/Pagination.tsx
@@ -46,7 +46,6 @@ interface Props
 const Pagination = (props: Props) => {
     const {
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -56,6 +55,9 @@ const Pagination = (props: Props) => {
     const onChange = (value: number) => {
         setProps({ value });
     };
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantinePagination

--- a/src/ts/components/core/Paper.tsx
+++ b/src/ts/components/core/Paper.tsx
@@ -30,6 +30,4 @@ const Paper = (props: Props) => {
     );
 };
 
-Paper.defaultProps = {};
-
 export default Paper;

--- a/src/ts/components/core/Paper.tsx
+++ b/src/ts/components/core/Paper.tsx
@@ -15,13 +15,14 @@ interface Props
 
 /** Paper */
 const Paper = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantinePaper
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Rating.tsx
+++ b/src/ts/components/core/Rating.tsx
@@ -38,7 +38,14 @@ interface Props
 
 /** Rating */
 const Rating = (props: Props) => {
-    const { setProps, value, ...others } = props;
+    const {
+        setProps,
+        value = 0,
+        persistence,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        ...others
+    } = props;
 
     const [val, setVal] = useState(value);
 
@@ -57,12 +64,6 @@ const Rating = (props: Props) => {
             {...others}
         />
     );
-};
-
-Rating.defaultProps = {
-    value: 0,
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default Rating;

--- a/src/ts/components/core/Rating.tsx
+++ b/src/ts/components/core/Rating.tsx
@@ -38,7 +38,7 @@ interface Props
 
 /** Rating */
 const Rating = (props: Props) => {
-    const { setProps, loading_state, value, ...others } = props;
+    const { setProps, value, ...others } = props;
 
     const [val, setVal] = useState(value);
 

--- a/src/ts/components/core/RingProgress.tsx
+++ b/src/ts/components/core/RingProgress.tsx
@@ -30,7 +30,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** RingProgress */
 const RingProgress = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
 
     return (
         <MantineRingProgress

--- a/src/ts/components/core/RingProgress.tsx
+++ b/src/ts/components/core/RingProgress.tsx
@@ -39,6 +39,4 @@ const RingProgress = (props: Props) => {
     );
 };
 
-RingProgress.defaultProps = {};
-
 export default RingProgress;

--- a/src/ts/components/core/ScrollArea.tsx
+++ b/src/ts/components/core/ScrollArea.tsx
@@ -27,13 +27,14 @@ interface Props extends ScrollAreaProps, DashBaseProps {
 
 /** ScrollArea */
 const ScrollArea = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineScrollArea
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/ScrollArea.tsx
+++ b/src/ts/components/core/ScrollArea.tsx
@@ -42,6 +42,4 @@ const ScrollArea = (props: Props) => {
     );
 };
 
-ScrollArea.defaultProps = {};
-
 export default ScrollArea;

--- a/src/ts/components/core/SegmentedControl.tsx
+++ b/src/ts/components/core/SegmentedControl.tsx
@@ -52,8 +52,8 @@ const SegmentedControl = (props: Props) => {
         data,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -86,11 +86,6 @@ const SegmentedControl = (props: Props) => {
             {...others}
         />
     );
-};
-
-SegmentedControl.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default SegmentedControl;

--- a/src/ts/components/core/SegmentedControl.tsx
+++ b/src/ts/components/core/SegmentedControl.tsx
@@ -51,7 +51,6 @@ const SegmentedControl = (props: Props) => {
     const {
         data,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -76,11 +75,12 @@ const SegmentedControl = (props: Props) => {
         setProps({ value });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineSegmentedControl
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             data={renderedData}
             onChange={onChange}
             {...others}

--- a/src/ts/components/core/SemiCircleProgress.tsx
+++ b/src/ts/components/core/SemiCircleProgress.tsx
@@ -41,7 +41,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Use to represent progress with semi circle diagram */
 const SemiCircleProgress = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
 
     return (
         <MantineSemiCircleProgess

--- a/src/ts/components/core/SemiCircleProgress.tsx
+++ b/src/ts/components/core/SemiCircleProgress.tsx
@@ -50,6 +50,4 @@ const SemiCircleProgress = (props: Props) => {
     );
 };
 
-SemiCircleProgress.defaultProps = {};
-
 export default SemiCircleProgress;

--- a/src/ts/components/core/SimpleGrid.tsx
+++ b/src/ts/components/core/SimpleGrid.tsx
@@ -21,13 +21,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** SimpleGrid */
 const SimpleGrid = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineSimpleGrid
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/SimpleGrid.tsx
+++ b/src/ts/components/core/SimpleGrid.tsx
@@ -36,6 +36,4 @@ const SimpleGrid = (props: Props) => {
     );
 };
 
-SimpleGrid.defaultProps = {};
-
 export default SimpleGrid;

--- a/src/ts/components/core/Skeleton.tsx
+++ b/src/ts/components/core/Skeleton.tsx
@@ -23,7 +23,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Skeleton */
 const Skeleton = (props: Props) => {
-    const { setProps, visible,  children, ...others } = props;
+    const { setProps, visible = true,  children, ...others } = props;
     const ctx = (window as any).dash_component_api.useDashContext();
     const loading = ctx.useLoading();
 
@@ -38,9 +38,5 @@ const Skeleton = (props: Props) => {
 };
 
 Skeleton._dashprivate_isLoadingComponent = true;
-
-Skeleton.defaultProps = {
-    visible: true,
-};
 
 export default Skeleton;

--- a/src/ts/components/core/Skeleton.tsx
+++ b/src/ts/components/core/Skeleton.tsx
@@ -23,12 +23,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Skeleton */
 const Skeleton = (props: Props) => {
-    const { setProps, visible, loading_state, children, ...others } = props;
+    const { setProps, visible,  children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineSkeleton
             {...others}
-            visible={visible || (loading_state && loading_state.is_loading)}
+            visible={visible || loading}
         >
             {children}
         </MantineSkeleton>

--- a/src/ts/components/core/Space.tsx
+++ b/src/ts/components/core/Space.tsx
@@ -20,6 +20,4 @@ const Space = (props: Props) => {
     );
 };
 
-Space.defaultProps = {};
-
 export default Space;

--- a/src/ts/components/core/Space.tsx
+++ b/src/ts/components/core/Space.tsx
@@ -10,13 +10,9 @@ interface Props extends BoxProps, DashBaseProps {
 
 /** Space */
 const Space = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
-
+    const { children, setProps, ...others } = props;
     return (
         <MantineSpace
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         >
             {children}

--- a/src/ts/components/core/Spoiler.tsx
+++ b/src/ts/components/core/Spoiler.tsx
@@ -24,7 +24,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Spoiler */
 const Spoiler = (props: Props) => {
-    const { setProps, loading_state, expanded, children, ...others } = props;
+    const { setProps, expanded, children, ...others } = props;
 
     const [opened, setOpened] = useState(expanded);
 
@@ -36,11 +36,12 @@ const Spoiler = (props: Props) => {
         setOpened(expanded);
     }, [expanded]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineSpoiler
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             expanded={opened}
             onExpandedChange={setOpened}
             {...others}

--- a/src/ts/components/core/Spoiler.tsx
+++ b/src/ts/components/core/Spoiler.tsx
@@ -24,7 +24,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Spoiler */
 const Spoiler = (props: Props) => {
-    const { setProps, expanded, children, ...others } = props;
+    const { setProps, expanded = false, children, ...others } = props;
 
     const [opened, setOpened] = useState(expanded);
 
@@ -49,10 +49,6 @@ const Spoiler = (props: Props) => {
             {children}
         </MantineSpoiler>
     );
-};
-
-Spoiler.defaultProps = {
-    expanded: false,
 };
 
 export default Spoiler;

--- a/src/ts/components/core/Stack.tsx
+++ b/src/ts/components/core/Stack.tsx
@@ -32,6 +32,4 @@ const Stack = (props: Props) => {
     );
 };
 
-Stack.defaultProps = {};
-
 export default Stack;

--- a/src/ts/components/core/Stack.tsx
+++ b/src/ts/components/core/Stack.tsx
@@ -17,13 +17,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Stack */
 const Stack = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineStack
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Switch.tsx
+++ b/src/ts/components/core/Switch.tsx
@@ -46,7 +46,6 @@ interface Props
 const Switch = (props: Props) => {
     const {
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,

--- a/src/ts/components/core/Switch.tsx
+++ b/src/ts/components/core/Switch.tsx
@@ -47,8 +47,8 @@ const Switch = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['checked'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -62,11 +62,6 @@ const Switch = (props: Props) => {
             {...others}
         />
     );
-};
-
-Switch.defaultProps = {
-    persisted_props: ["checked"],
-    persistence_type: "local",
 };
 
 export default Switch;

--- a/src/ts/components/core/Text.tsx
+++ b/src/ts/components/core/Text.tsx
@@ -8,15 +8,16 @@ interface Props extends TextProps, DashBaseProps {
     children?: React.ReactNode;
 }
 
-/** Text */
+/** Captures string input from user */
 const Text = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext()
+    const loading = ctx.useLoading();
 
     return (
         <MantineText
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+             data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Text.tsx
+++ b/src/ts/components/core/Text.tsx
@@ -25,6 +25,4 @@ const Text = (props: Props) => {
     );
 };
 
-Text.defaultProps = {};
-
 export default Text;

--- a/src/ts/components/core/ThemeIcon.tsx
+++ b/src/ts/components/core/ThemeIcon.tsx
@@ -27,7 +27,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ThemeIcon */
 const ThemeIcon = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
 
     return (
         <MantineThemeIcon

--- a/src/ts/components/core/ThemeIcon.tsx
+++ b/src/ts/components/core/ThemeIcon.tsx
@@ -38,6 +38,4 @@ const ThemeIcon = (props: Props) => {
     );
 };
 
-ThemeIcon.defaultProps = {};
-
 export default ThemeIcon;

--- a/src/ts/components/core/Title.tsx
+++ b/src/ts/components/core/Title.tsx
@@ -19,13 +19,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** Title */
 const Title = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineTitle
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/Title.tsx
+++ b/src/ts/components/core/Title.tsx
@@ -33,6 +33,4 @@ const Title = (props: Props) => {
     );
 };
 
-Title.defaultProps = {};
-
 export default Title;

--- a/src/ts/components/core/VisuallyHidden.tsx
+++ b/src/ts/components/core/VisuallyHidden.tsx
@@ -25,6 +25,4 @@ const VisuallyHidden = (props: Props) => {
     );
 };
 
-VisuallyHidden.defaultProps = {};
-
 export default VisuallyHidden;

--- a/src/ts/components/core/VisuallyHidden.tsx
+++ b/src/ts/components/core/VisuallyHidden.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** VisuallyHidden */
 const VisuallyHidden = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineVisuallyHidden
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/accordion/Accordion.tsx
+++ b/src/ts/components/core/accordion/Accordion.tsx
@@ -46,7 +46,6 @@ const Accordion = (props: Props) => {
     const {
         children,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -57,11 +56,12 @@ const Accordion = (props: Props) => {
         setProps({ value });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineAccordion
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={onChange}
             {...others}
         >

--- a/src/ts/components/core/accordion/Accordion.tsx
+++ b/src/ts/components/core/accordion/Accordion.tsx
@@ -47,8 +47,8 @@ const Accordion = (props: Props) => {
         children,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["value"],
+        persistence_type = "local",
         ...others
     } = props;
 
@@ -68,11 +68,6 @@ const Accordion = (props: Props) => {
             {children}
         </MantineAccordion>
     );
-};
-
-Accordion.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default Accordion;

--- a/src/ts/components/core/accordion/AccordionControl.tsx
+++ b/src/ts/components/core/accordion/AccordionControl.tsx
@@ -31,6 +31,4 @@ const AccordionControl = (props: Props) => {
     );
 };
 
-AccordionControl.defaultProps = {};
-
 export default AccordionControl;

--- a/src/ts/components/core/accordion/AccordionControl.tsx
+++ b/src/ts/components/core/accordion/AccordionControl.tsx
@@ -17,13 +17,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionControl */
 const AccordionControl = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Accordion.Control
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/accordion/AccordionItem.tsx
+++ b/src/ts/components/core/accordion/AccordionItem.tsx
@@ -27,6 +27,4 @@ const AccordionItem = (props: Props) => {
     );
 };
 
-AccordionItem.defaultProps = {};
-
 export default AccordionItem;

--- a/src/ts/components/core/accordion/AccordionItem.tsx
+++ b/src/ts/components/core/accordion/AccordionItem.tsx
@@ -13,13 +13,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionItem */
 const AccordionItem = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Accordion.Item
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/accordion/AccordionPanel.tsx
+++ b/src/ts/components/core/accordion/AccordionPanel.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AccordionPanel */
 const AccordionPanel = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Accordion.Panel
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/accordion/AccordionPanel.tsx
+++ b/src/ts/components/core/accordion/AccordionPanel.tsx
@@ -25,6 +25,4 @@ const AccordionPanel = (props: Props) => {
     );
 };
 
-AccordionPanel.defaultProps = {};
-
 export default AccordionPanel;

--- a/src/ts/components/core/appshell/AppShell.tsx
+++ b/src/ts/components/core/appshell/AppShell.tsx
@@ -57,6 +57,4 @@ const AppShell = (props: Props) => {
     );
 };
 
-AppShell.defaultProps = {};
-
 export default AppShell;

--- a/src/ts/components/core/appshell/AppShell.tsx
+++ b/src/ts/components/core/appshell/AppShell.tsx
@@ -43,13 +43,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShell */
 const AppShell = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineAppShell
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellAside.tsx
+++ b/src/ts/components/core/appshell/AppShellAside.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellAside */
 const AppShellAside = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Aside
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellAside.tsx
+++ b/src/ts/components/core/appshell/AppShellAside.tsx
@@ -29,6 +29,4 @@ const AppShellAside = (props: Props) => {
     );
 };
 
-AppShellAside.defaultProps = {};
-
 export default AppShellAside;

--- a/src/ts/components/core/appshell/AppShellFooter.tsx
+++ b/src/ts/components/core/appshell/AppShellFooter.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellFooter */
 const AppShellFooter = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Footer
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellFooter.tsx
+++ b/src/ts/components/core/appshell/AppShellFooter.tsx
@@ -29,6 +29,4 @@ const AppShellFooter = (props: Props) => {
     );
 };
 
-AppShellFooter.defaultProps = {};
-
 export default AppShellFooter;

--- a/src/ts/components/core/appshell/AppShellHeader.tsx
+++ b/src/ts/components/core/appshell/AppShellHeader.tsx
@@ -29,6 +29,4 @@ const AppShellHeader = (props: Props) => {
     );
 };
 
-AppShellHeader.defaultProps = {};
-
 export default AppShellHeader;

--- a/src/ts/components/core/appshell/AppShellHeader.tsx
+++ b/src/ts/components/core/appshell/AppShellHeader.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellHeader */
 const AppShellHeader = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Header
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellMain.tsx
+++ b/src/ts/components/core/appshell/AppShellMain.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellMain */
 const AppShellMain = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Main
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellMain.tsx
+++ b/src/ts/components/core/appshell/AppShellMain.tsx
@@ -25,6 +25,4 @@ const AppShellMain = (props: Props) => {
     );
 };
 
-AppShellMain.defaultProps = {};
-
 export default AppShellMain;

--- a/src/ts/components/core/appshell/AppShellNavbar.tsx
+++ b/src/ts/components/core/appshell/AppShellNavbar.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellNavbar */
 const AppShellNavbar = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Navbar
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/appshell/AppShellNavbar.tsx
+++ b/src/ts/components/core/appshell/AppShellNavbar.tsx
@@ -29,6 +29,4 @@ const AppShellNavbar = (props: Props) => {
     );
 };
 
-AppShellNavbar.defaultProps = {};
-
 export default AppShellNavbar;

--- a/src/ts/components/core/appshell/AppShellSection.tsx
+++ b/src/ts/components/core/appshell/AppShellSection.tsx
@@ -27,6 +27,4 @@ const AppShellSection = (props: Props) => {
     );
 };
 
-AppShellSection.defaultProps = {};
-
 export default AppShellSection;

--- a/src/ts/components/core/appshell/AppShellSection.tsx
+++ b/src/ts/components/core/appshell/AppShellSection.tsx
@@ -13,13 +13,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AppShellSection */
 const AppShellSection = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <AppShell.Section
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/avatar/Avatar.tsx
+++ b/src/ts/components/core/avatar/Avatar.tsx
@@ -49,6 +49,4 @@ const Avatar = (props: Props) => {
     );
 };
 
-Avatar.defaultProps = {};
-
 export default Avatar;

--- a/src/ts/components/core/avatar/Avatar.tsx
+++ b/src/ts/components/core/avatar/Avatar.tsx
@@ -35,13 +35,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Use the Avatar component to display user profile image, initials or fallback icon */
 const Avatar = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineAvatar
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/avatar/AvatarGroup.tsx
+++ b/src/ts/components/core/avatar/AvatarGroup.tsx
@@ -13,13 +13,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** AvatarGroup */
 const AvatarGroup = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Avatar.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/avatar/AvatarGroup.tsx
+++ b/src/ts/components/core/avatar/AvatarGroup.tsx
@@ -27,6 +27,4 @@ const AvatarGroup = (props: Props) => {
     );
 };
 
-AvatarGroup.defaultProps = {};
-
 export default AvatarGroup;

--- a/src/ts/components/core/button/ActionIcon.tsx
+++ b/src/ts/components/core/button/ActionIcon.tsx
@@ -10,7 +10,7 @@ interface Props extends ActionIconProps, DashBaseProps {
 
 /** ActionIcon */
 const ActionIcon = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks = 0, ...others } =
         props;
 
     const increment = () => {
@@ -34,10 +34,6 @@ const ActionIcon = (props: Props) => {
             {children}
         </MantineActionIcon>
     );
-};
-
-ActionIcon.defaultProps = {
-    n_clicks: 0,
 };
 
 export default ActionIcon;

--- a/src/ts/components/core/button/ActionIcon.tsx
+++ b/src/ts/components/core/button/ActionIcon.tsx
@@ -10,7 +10,7 @@ interface Props extends ActionIconProps, DashBaseProps {
 
 /** ActionIcon */
 const ActionIcon = (props: Props) => {
-    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks, ...others } =
         props;
 
     const increment = () => {
@@ -21,11 +21,12 @@ const ActionIcon = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineActionIcon
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             disabled={disabled}
             onClick={increment}
             {...others}

--- a/src/ts/components/core/button/ActionIconGroup.tsx
+++ b/src/ts/components/core/button/ActionIconGroup.tsx
@@ -15,13 +15,14 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ActionIconGroup */
 const ActionIconGroup = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <ActionIcon.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/button/ActionIconGroup.tsx
+++ b/src/ts/components/core/button/ActionIconGroup.tsx
@@ -30,6 +30,4 @@ const ActionIconGroup = (props: Props) => {
     );
 };
 
-ActionIconGroup.defaultProps = {};
-
 export default ActionIconGroup;

--- a/src/ts/components/core/button/Button.tsx
+++ b/src/ts/components/core/button/Button.tsx
@@ -44,7 +44,7 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Button */
 const Button = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks = 0, ...others } =
         props;
 
     const increment = () => {
@@ -68,10 +68,6 @@ const Button = (props: Props) => {
             {children}
         </MantineButton>
     );
-};
-
-Button.defaultProps = {
-    n_clicks: 0,
 };
 
 export default Button;

--- a/src/ts/components/core/button/Button.tsx
+++ b/src/ts/components/core/button/Button.tsx
@@ -44,7 +44,7 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** Button */
 const Button = (props: Props) => {
-    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks, ...others } =
         props;
 
     const increment = () => {
@@ -55,11 +55,12 @@ const Button = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineButton
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onClick={increment}
             disabled={disabled}
             {...others}

--- a/src/ts/components/core/button/ButtonGroup.tsx
+++ b/src/ts/components/core/button/ButtonGroup.tsx
@@ -29,6 +29,4 @@ const ButtonGroup = (props: Props) => {
     );
 };
 
-ButtonGroup.defaultProps = {};
-
 export default ButtonGroup;

--- a/src/ts/components/core/button/ButtonGroup.tsx
+++ b/src/ts/components/core/button/ButtonGroup.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** ButtonGroup */
 const ButtonGroup = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Button.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/button/UnstyledButton.tsx
+++ b/src/ts/components/core/button/UnstyledButton.tsx
@@ -18,7 +18,7 @@ export interface Props
 
 /** UnstyledButton */
 const UnstyledButton = (props: Props) => {
-    const { children, setProps, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks = 0, ...others } =
         props;
 
     const increment = () => {
@@ -42,10 +42,6 @@ const UnstyledButton = (props: Props) => {
             {children}
         </MantineUnstyledButton>
     );
-};
-
-UnstyledButton.defaultProps = {
-    n_clicks: 0,
 };
 
 export default UnstyledButton;

--- a/src/ts/components/core/button/UnstyledButton.tsx
+++ b/src/ts/components/core/button/UnstyledButton.tsx
@@ -18,7 +18,7 @@ export interface Props
 
 /** UnstyledButton */
 const UnstyledButton = (props: Props) => {
-    const { children, setProps, loading_state, disabled, n_clicks, ...others } =
+    const { children, setProps, disabled, n_clicks, ...others } =
         props;
 
     const increment = () => {
@@ -29,11 +29,12 @@ const UnstyledButton = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineUnstyledButton
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onClick={increment}
             disabled={disabled}
             {...others}

--- a/src/ts/components/core/card/Card.tsx
+++ b/src/ts/components/core/card/Card.tsx
@@ -24,13 +24,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Card */
 const Card = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineCard
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/card/Card.tsx
+++ b/src/ts/components/core/card/Card.tsx
@@ -39,6 +39,4 @@ const Card = (props: Props) => {
     );
 };
 
-Card.defaultProps = {};
-
 export default Card;

--- a/src/ts/components/core/card/CardSection.tsx
+++ b/src/ts/components/core/card/CardSection.tsx
@@ -15,13 +15,14 @@ export interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CardSection */
 const CardSection = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Card.Section
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/card/CardSection.tsx
+++ b/src/ts/components/core/card/CardSection.tsx
@@ -30,6 +30,4 @@ const CardSection = (props: Props) => {
     );
 };
 
-CardSection.defaultProps = {};
-
 export default CardSection;

--- a/src/ts/components/core/checkbox/Checkbox.tsx
+++ b/src/ts/components/core/checkbox/Checkbox.tsx
@@ -63,8 +63,7 @@ const Checkbox = (props: Props) => {
 
     const iconFunc = ({ indeterminate, ...others }) => {
         const selected: any = indeterminate ? indeterminateIcon : icon;
-        Object.assign(selected.props._dashprivate_layout.props, others);
-        return selected;
+        return React.cloneElement(selected, {extras: others});
     };
 
     return (

--- a/src/ts/components/core/checkbox/Checkbox.tsx
+++ b/src/ts/components/core/checkbox/Checkbox.tsx
@@ -48,7 +48,7 @@ interface Props
     indeterminateIcon?: React.ReactNode;
 }
 
-/** Checkbox */
+/** Use Checkbox to capture boolean input from user */
 const Checkbox = (props: Props) => {
     const {
         setProps,

--- a/src/ts/components/core/checkbox/Checkbox.tsx
+++ b/src/ts/components/core/checkbox/Checkbox.tsx
@@ -52,7 +52,6 @@ interface Props
 const Checkbox = (props: Props) => {
     const {
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -66,11 +65,12 @@ const Checkbox = (props: Props) => {
         return React.cloneElement(selected, {extras: others});
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineCheckbox
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={(ev) => setProps({ checked: ev.currentTarget.checked })}
             icon={icon || indeterminateIcon ? iconFunc : undefined}
             {...others}

--- a/src/ts/components/core/checkbox/Checkbox.tsx
+++ b/src/ts/components/core/checkbox/Checkbox.tsx
@@ -53,8 +53,8 @@ const Checkbox = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["value"],
+        persistence_type = "local",
         icon,
         indeterminateIcon,
         ...others
@@ -62,7 +62,7 @@ const Checkbox = (props: Props) => {
 
     const iconFunc = ({ indeterminate, ...others }) => {
         const selected: any = indeterminate ? indeterminateIcon : icon;
-        return React.cloneElement(selected, {extras: others});
+        return React.cloneElement(selected, {...others});
     };
 
     const ctx = (window as any).dash_component_api.useDashContext();
@@ -76,12 +76,6 @@ const Checkbox = (props: Props) => {
             {...others}
         />
     );
-};
-
-Checkbox.defaultProps = {
-    persisted_props: ["checked"],
-    persistence_type: "local",
-    checked: false,
 };
 
 export default Checkbox;

--- a/src/ts/components/core/checkbox/CheckboxGroup.tsx
+++ b/src/ts/components/core/checkbox/CheckboxGroup.tsx
@@ -29,8 +29,9 @@ const CheckboxGroup = (props: Props) => {
         children,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        value = [],
         ...others
     } = props;
 
@@ -45,17 +46,12 @@ const CheckboxGroup = (props: Props) => {
         <Checkbox.Group
             data-dash-is-loading={loading || undefined}
             onChange={onChange}
+            value={value}
             {...others}
         >
             {children}
         </Checkbox.Group>
     );
-};
-
-CheckboxGroup.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    value: [],
 };
 
 export default CheckboxGroup;

--- a/src/ts/components/core/checkbox/CheckboxGroup.tsx
+++ b/src/ts/components/core/checkbox/CheckboxGroup.tsx
@@ -28,7 +28,6 @@ const CheckboxGroup = (props: Props) => {
     const {
         children,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -39,11 +38,12 @@ const CheckboxGroup = (props: Props) => {
         setProps({ value });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <Checkbox.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={onChange}
             {...others}
         >

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -50,7 +50,6 @@ const Chip = (props: Props) => {
         persisted_props,
         persistence_type,
         checked,
-        loading_state,
         ...others
     } = props;
 
@@ -67,11 +66,12 @@ const Chip = (props: Props) => {
         ? { onClick: chipGroupContext?.chipOnClick }
         : { checked, onChange };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineChip
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...eventProps}
             {...others}
         >

--- a/src/ts/components/core/chip/Chip.tsx
+++ b/src/ts/components/core/chip/Chip.tsx
@@ -47,8 +47,8 @@ const Chip = (props: Props) => {
         children,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["checked"],
+        persistence_type = "local",
         checked,
         ...others
     } = props;
@@ -78,11 +78,6 @@ const Chip = (props: Props) => {
             {children}
         </MantineChip>
     );
-};
-
-Chip.defaultProps = {
-    persisted_props: ["checked"],
-    persistence_type: "local",
 };
 
 export default Chip;

--- a/src/ts/components/core/chip/ChipGroup.tsx
+++ b/src/ts/components/core/chip/ChipGroup.tsx
@@ -22,8 +22,8 @@ const ChipGroup = (props: Props) => {
         value,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["value"],
+        persistence_type = "local",
         deselectable,
         ...others
     } = props;
@@ -60,9 +60,5 @@ const ChipGroup = (props: Props) => {
     );
 };
 
-ChipGroup.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-};
 
 export default ChipGroup;

--- a/src/ts/components/core/chip/ChipGroup.tsx
+++ b/src/ts/components/core/chip/ChipGroup.tsx
@@ -24,7 +24,6 @@ const ChipGroup = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         deselectable,
         ...others
     } = props;
@@ -44,13 +43,14 @@ const ChipGroup = (props: Props) => {
         }
       };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <Chip.Group
             value={val}
             onChange={setVal}
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             <ChipGroupContext.Provider value={{ chipOnClick: deselectable ? handleChipClick : null }}>

--- a/src/ts/components/core/color/ColorInput.tsx
+++ b/src/ts/components/core/color/ColorInput.tsx
@@ -12,8 +12,8 @@ const ColorInput = (props: Props) => {
         setProps,
         value,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["value"],
+        persistence_type = "local",
         ...others
     } = props;
 
@@ -38,11 +38,6 @@ const ColorInput = (props: Props) => {
             {...others}
         />
     );
-};
-
-ColorInput.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default ColorInput;

--- a/src/ts/components/core/color/ColorInput.tsx
+++ b/src/ts/components/core/color/ColorInput.tsx
@@ -10,7 +10,6 @@ interface Props extends ColorInputProps, PersistenceProps, DashBaseProps {}
 const ColorInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         value,
         persistence,
         persisted_props,
@@ -28,11 +27,12 @@ const ColorInput = (props: Props) => {
         setColor(value);
     }, [value]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineColorInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             value={color}
             onChange={setColor}
             {...others}

--- a/src/ts/components/core/color/ColorPicker.tsx
+++ b/src/ts/components/core/color/ColorPicker.tsx
@@ -10,7 +10,6 @@ interface Props extends ColorPickerProps, PersistenceProps, DashBaseProps {}
 const ColorPicker = (props: Props) => {
     const {
         setProps,
-        loading_state,
         value,
         persistence,
         persisted_props,
@@ -28,11 +27,12 @@ const ColorPicker = (props: Props) => {
         setColor(value);
     }, [value]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineColorPicker
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             value={color}
             onChange={setColor}
             {...others}

--- a/src/ts/components/core/color/ColorPicker.tsx
+++ b/src/ts/components/core/color/ColorPicker.tsx
@@ -12,8 +12,8 @@ const ColorPicker = (props: Props) => {
         setProps,
         value,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ["value"],
+        persistence_type = "local",
         ...others
     } = props;
 
@@ -38,11 +38,6 @@ const ColorPicker = (props: Props) => {
             {...others}
         />
     );
-};
-
-ColorPicker.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default ColorPicker;

--- a/src/ts/components/core/combobox/Autocomplete.tsx
+++ b/src/ts/components/core/combobox/Autocomplete.tsx
@@ -28,7 +28,15 @@ interface Props
 
 /** Autocomplete */
 const Autocomplete = (props: Props) => {
-    const { setProps, data, value, ...others } = props;
+    const {
+        setProps,
+        data = [],
+        value,
+        persistence,
+        persisted_props = ["value"],
+        persistence_type = "local",
+         ...others
+     } = props;
 
     const [autocomplete, setAutocomplete] = useState(value);
     const [options, setOptions] = useState(data);
@@ -62,12 +70,6 @@ const Autocomplete = (props: Props) => {
             {...others}
         />
     );
-};
-
-Autocomplete.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    data: [],
 };
 
 export default Autocomplete;

--- a/src/ts/components/core/combobox/Autocomplete.tsx
+++ b/src/ts/components/core/combobox/Autocomplete.tsx
@@ -28,7 +28,7 @@ interface Props
 
 /** Autocomplete */
 const Autocomplete = (props: Props) => {
-    const { setProps, loading_state, data, value, ...others } = props;
+    const { setProps, data, value, ...others } = props;
 
     const [autocomplete, setAutocomplete] = useState(value);
     const [options, setOptions] = useState(data);
@@ -49,11 +49,12 @@ const Autocomplete = (props: Props) => {
         setAutocomplete(value);
     }, [value]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineAutocomplete
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             wrapperProps={{ autoComplete: "off" }}
             data={options}
             onChange={setAutocomplete}

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -51,13 +51,13 @@ const MultiSelect = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        debounce,
-        n_submit,
-        n_blur,
-        data,
-        value,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        debounce = false,
+        n_submit = 0,
+        n_blur = 0,
+        data = [],
+        value = [],
         ...others
     } = props;
 
@@ -131,16 +131,6 @@ const MultiSelect = (props: Props) => {
             />
         </div>
     );
-};
-
-MultiSelect.defaultProps = {
-    debounce: false,
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
-    data: [],
-    value: [],
 };
 
 export default MultiSelect;

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -53,7 +53,6 @@ const MultiSelect = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         debounce,
         n_submit,
         n_blur,
@@ -115,12 +114,13 @@ const MultiSelect = (props: Props) => {
         setProps({ data: options });
     }, [options]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <div ref={ref}>
             <MantineMultiSelect
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined}
                 onKeyDown={handleKeyDown}
                 onBlur={handleBlur}
                 data={options}

--- a/src/ts/components/core/combobox/Select.tsx
+++ b/src/ts/components/core/combobox/Select.tsx
@@ -47,12 +47,12 @@ const Select = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        debounce,
-        n_submit,
-        n_blur,
-        data,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        debounce = false,
+        n_submit = 0,
+        n_blur = 0,
+        data = [],
         searchValue,
         value,
         ...others
@@ -123,15 +123,6 @@ const Select = (props: Props) => {
             {...others}
         />
     );
-};
-
-Select.defaultProps = {
-    debounce: false,
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
-    data: [],
 };
 
 export default Select;

--- a/src/ts/components/core/combobox/Select.tsx
+++ b/src/ts/components/core/combobox/Select.tsx
@@ -49,7 +49,6 @@ const Select = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         debounce,
         n_submit,
         n_blur,
@@ -108,11 +107,12 @@ const Select = (props: Props) => {
         setProps({ searchValue: searchVal });
     }, [searchVal]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineSelect
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             data={options}

--- a/src/ts/components/core/combobox/TagsInput.tsx
+++ b/src/ts/components/core/combobox/TagsInput.tsx
@@ -48,8 +48,7 @@ interface Props
 
 /** TagsInput captures a list of values from user with free input and suggestions */
 const TagsInput = (props: Props) => {
-    const { setProps, loading_state, data, searchValue, value, ...others } =
-        props;
+    const { setProps, data, searchValue, value, ...others } = props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
@@ -77,11 +76,12 @@ const TagsInput = (props: Props) => {
         setProps({ searchValue: searchVal });
     }, [searchVal]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineTagsInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             data={options}
             onChange={setSelected}
             value={selected}

--- a/src/ts/components/core/combobox/TagsInput.tsx
+++ b/src/ts/components/core/combobox/TagsInput.tsx
@@ -48,7 +48,16 @@ interface Props
 
 /** TagsInput captures a list of values from user with free input and suggestions */
 const TagsInput = (props: Props) => {
-    const { setProps, data, searchValue, value, ...others } = props;
+    const {
+        setProps,
+        data = [],
+        searchValue,
+        value = [],
+        persistence,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+         ...others
+      } = props;
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
@@ -90,13 +99,6 @@ const TagsInput = (props: Props) => {
             {...others}
         />
     );
-};
-
-TagsInput.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    data: [],
-    value: [],
 };
 
 export default TagsInput;

--- a/src/ts/components/core/grid/Grid.tsx
+++ b/src/ts/components/core/grid/Grid.tsx
@@ -23,13 +23,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Grid */
 const Grid = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineGrid
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/grid/Grid.tsx
+++ b/src/ts/components/core/grid/Grid.tsx
@@ -38,6 +38,4 @@ const Grid = (props: Props) => {
     );
 };
 
-Grid.defaultProps = {};
-
 export default Grid;

--- a/src/ts/components/core/grid/GridCol.tsx
+++ b/src/ts/components/core/grid/GridCol.tsx
@@ -18,13 +18,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** GridCol */
 const GridCol = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Grid.Col
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/grid/GridCol.tsx
+++ b/src/ts/components/core/grid/GridCol.tsx
@@ -32,6 +32,4 @@ const GridCol = (props: Props) => {
     );
 };
 
-GridCol.defaultProps = {};
-
 export default GridCol;

--- a/src/ts/components/core/hovercard/HoverCard.tsx
+++ b/src/ts/components/core/hovercard/HoverCard.tsx
@@ -10,7 +10,7 @@ interface Props extends Omit<PopoverProps, "opened">, DashBaseProps {
     closeDelay?: number;
 }
 
-/** HoverCard */
+/** Use HoverCard to display popover section when target element is hovered */
 const HoverCard = (props: Props) => {
     const { children, setProps, loading_state, ...others } = props;
 
@@ -22,7 +22,7 @@ const HoverCard = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const {type: childType, props: childProps} = child.props._dashprivate_layout;
+                const {type: childType, props: childProps} = window.dash_clientside.get_layout(child.props.componentPath);
                 if (childType === "HoverCardTarget") {
                     const { boxWrapperProps } = childProps;
                     return (

--- a/src/ts/components/core/hovercard/HoverCard.tsx
+++ b/src/ts/components/core/hovercard/HoverCard.tsx
@@ -37,6 +37,4 @@ const HoverCard = (props: Props) => {
     );
 };
 
-HoverCard.defaultProps = {};
-
 export default HoverCard;

--- a/src/ts/components/core/hovercard/HoverCard.tsx
+++ b/src/ts/components/core/hovercard/HoverCard.tsx
@@ -12,13 +12,13 @@ interface Props extends Omit<PopoverProps, "opened">, DashBaseProps {
 
 /** Use HoverCard to display popover section when target element is hovered */
 const HoverCard = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineHoverCard
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {

--- a/src/ts/components/core/hovercard/HoverCardDropdown.tsx
+++ b/src/ts/components/core/hovercard/HoverCardDropdown.tsx
@@ -25,6 +25,4 @@ const HoverCardDropdown = (props: Props) => {
     );
 };
 
-HoverCardDropdown.defaultProps = {};
-
 export default HoverCardDropdown;

--- a/src/ts/components/core/hovercard/HoverCardDropdown.tsx
+++ b/src/ts/components/core/hovercard/HoverCardDropdown.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** HoverCardDropdown */
 const HoverCardDropdown = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps,  ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <HoverCard.Dropdown
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/hovercard/HoverCardTarget.tsx
+++ b/src/ts/components/core/hovercard/HoverCardTarget.tsx
@@ -15,6 +15,4 @@ const HoverCardTarget = (props: Props) => {
     return <>{children}</>;
 };
 
-HoverCardTarget.defaultProps = {};
-
 export default HoverCardTarget;

--- a/src/ts/components/core/image/BackgroundImage.tsx
+++ b/src/ts/components/core/image/BackgroundImage.tsx
@@ -18,13 +18,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** BackgroundImage  */
 const BackgroundImage = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineBackgroundImage
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/image/BackgroundImage.tsx
+++ b/src/ts/components/core/image/BackgroundImage.tsx
@@ -32,6 +32,4 @@ const BackgroundImage = (props: Props) => {
     );
 };
 
-BackgroundImage.defaultProps = {};
-
 export default BackgroundImage;

--- a/src/ts/components/core/image/Image.tsx
+++ b/src/ts/components/core/image/Image.tsx
@@ -19,13 +19,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Image  */
 const Image = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineImage
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/image/Image.tsx
+++ b/src/ts/components/core/image/Image.tsx
@@ -31,6 +31,4 @@ const Image = (props: Props) => {
     );
 };
 
-Image.defaultProps = {};
-
 export default Image;

--- a/src/ts/components/core/input/JsonInput.tsx
+++ b/src/ts/components/core/input/JsonInput.tsx
@@ -22,7 +22,6 @@ const JsonInput = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         value,
         n_submit,
         n_blur,
@@ -60,11 +59,12 @@ const JsonInput = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineJsonInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={setVal}
             value={val}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/core/input/JsonInput.tsx
+++ b/src/ts/components/core/input/JsonInput.tsx
@@ -20,12 +20,13 @@ const JsonInput = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        value,
-        n_submit,
-        n_blur,
-        debounce,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        value = '',
+        n_submit = 0,
+        n_blur = 0,
+        debounce = false,
+        autoComplete = "off",
         ...others
     } = props;
 
@@ -69,19 +70,10 @@ const JsonInput = (props: Props) => {
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            autoComplete={autoComplete}
             {...others}
         />
     );
-};
-
-JsonInput.defaultProps = {
-    debounce: false,
-    value: "",
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur:0,
-    autoComplete: "off"
 };
 
 export default JsonInput;

--- a/src/ts/components/core/input/NumberInput.tsx
+++ b/src/ts/components/core/input/NumberInput.tsx
@@ -71,7 +71,6 @@ const NumberInput = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         value,
         n_submit,
         n_blur,
@@ -110,11 +109,12 @@ const NumberInput = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineNumberInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={setVal}
             value={val}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/core/input/NumberInput.tsx
+++ b/src/ts/components/core/input/NumberInput.tsx
@@ -69,12 +69,13 @@ const NumberInput = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        value,
-        n_submit,
-        n_blur,
-        debounce,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        value = '',
+        n_submit = 0,
+        n_blur = 0,
+        debounce = false,
+        autoComplete = "off",
         ...others
     } = props;
 
@@ -119,20 +120,10 @@ const NumberInput = (props: Props) => {
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            autoComplete={autoComplete}
             {...others}
         />
     );
-};
-
-
-NumberInput.defaultProps = {
-    debounce: false,
-    value: "",
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
-    autoComplete: "off"
 };
 
 export default NumberInput;

--- a/src/ts/components/core/input/PasswordInput.tsx
+++ b/src/ts/components/core/input/PasswordInput.tsx
@@ -28,7 +28,6 @@ const PasswordInput = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         value,
         n_submit,
         n_blur,
@@ -66,11 +65,12 @@ const PasswordInput = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantinePasswordInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/core/input/PasswordInput.tsx
+++ b/src/ts/components/core/input/PasswordInput.tsx
@@ -26,12 +26,12 @@ const PasswordInput = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        value,
-        n_submit,
-        n_blur,
-        debounce,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        value = '',
+        n_submit = 0,
+        n_blur = 0,
+        debounce = false,
         ...others
     } = props;
 
@@ -65,12 +65,8 @@ const PasswordInput = (props: Props) => {
         });
     };
 
-    const ctx = (window as any).dash_component_api.useDashContext();
-    const loading = ctx.useLoading();
-
     return (
         <MantinePasswordInput
-            data-dash-is-loading={loading || undefined}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}
             onKeyDown={handleKeyDown}
@@ -78,15 +74,6 @@ const PasswordInput = (props: Props) => {
             {...others}
         />
     );
-};
-
-PasswordInput.defaultProps = {
-    debounce: false,
-    value: "",
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
 };
 
 export default PasswordInput;

--- a/src/ts/components/core/input/PinInput.tsx
+++ b/src/ts/components/core/input/PinInput.tsx
@@ -67,13 +67,13 @@ interface Props
 
 /** PinInput */
 const PinInput = (props: Props) => {
-    const { setProps, loading_state, value, ...others } = props;
+    const { setProps, value, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantinePinInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onComplete={(value) => setProps({ value })}
             {...others}
         />

--- a/src/ts/components/core/input/PinInput.tsx
+++ b/src/ts/components/core/input/PinInput.tsx
@@ -68,18 +68,13 @@ interface Props
 /** PinInput */
 const PinInput = (props: Props) => {
     const { setProps, value, ...others } = props;
-    const ctx = (window as any).dash_component_api.useDashContext();
-    const loading = ctx.useLoading();
 
     return (
         <MantinePinInput
-            data-dash-is-loading={loading || undefined}
             onComplete={(value) => setProps({ value })}
             {...others}
         />
     );
 };
-
-PinInput.defaultProps = {};
 
 export default PinInput;

--- a/src/ts/components/core/input/TextInput.tsx
+++ b/src/ts/components/core/input/TextInput.tsx
@@ -28,7 +28,6 @@ const TextInput = (props: Props) => {
         persistence,
         persisted_props,
         persistence_type,
-        loading_state,
         value,
         n_submit,
         n_blur,
@@ -67,11 +66,12 @@ const TextInput = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineTextInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/core/input/TextInput.tsx
+++ b/src/ts/components/core/input/TextInput.tsx
@@ -26,12 +26,13 @@ const TextInput = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
-        value,
-        n_submit,
-        n_blur,
-        debounce,
+        persisted_props = ['value'],
+        persistence_type = 'local',
+        value = '',
+        n_submit = 0,
+        n_blur = 0,
+        debounce = false,
+        autoComplete = 'off',
         ...others
     } = props;
 
@@ -76,20 +77,10 @@ const TextInput = (props: Props) => {
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            autoComplete={autoComplete}
             {...others}
         />
     );
-};
-
-
-TextInput.defaultProps = {
-    debounce: false,
-    value: "",
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
-    autoComplete: "off"
 };
 
 export default TextInput;

--- a/src/ts/components/core/input/Textarea.tsx
+++ b/src/ts/components/core/input/Textarea.tsx
@@ -17,13 +17,14 @@ interface Props extends TextareaProps, DashBaseProps, DebounceProps, Persistence
 const Textarea = (props: Props) => {
     const {
         setProps,
-        value,
-        debounce,
-        n_blur,
-        n_submit,
+        value = '',
+        debounce = false,
+        n_blur = 0,
+        n_submit = 0,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'locaL',
+        autoComplete = "off",
         ...others
     } = props;
 
@@ -68,18 +69,9 @@ const Textarea = (props: Props) => {
             onChange={(ev) => setVal(ev.currentTarget.value)}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
+            autoComplete={autoComplete}
         />
     );
-};
-
-Textarea.defaultProps = {
-    debounce: false,
-    value: "",
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_blur: 0,
-    n_submit: 0,
-    autoComplete: "off"
 };
 
 export default Textarea;

--- a/src/ts/components/core/input/Textarea.tsx
+++ b/src/ts/components/core/input/Textarea.tsx
@@ -17,7 +17,6 @@ interface Props extends TextareaProps, DashBaseProps, DebounceProps, Persistence
 const Textarea = (props: Props) => {
     const {
         setProps,
-        loading_state,
         value,
         debounce,
         n_blur,
@@ -58,11 +57,12 @@ const Textarea = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineTextarea
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
             value={val}
             onChange={(ev) => setVal(ev.currentTarget.value)}

--- a/src/ts/components/core/list/List.tsx
+++ b/src/ts/components/core/list/List.tsx
@@ -44,6 +44,4 @@ const List = (props: Props) => {
     );
 };
 
-List.defaultProps = {};
-
 export default List;

--- a/src/ts/components/core/list/List.tsx
+++ b/src/ts/components/core/list/List.tsx
@@ -29,13 +29,14 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** List */
 const List = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineList
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/list/ListItem.tsx
+++ b/src/ts/components/core/list/ListItem.tsx
@@ -27,6 +27,4 @@ const ListItem = (props: Props) => {
     );
 };
 
-ListItem.defaultProps = {};
-
 export default ListItem;

--- a/src/ts/components/core/list/ListItem.tsx
+++ b/src/ts/components/core/list/ListItem.tsx
@@ -13,13 +13,13 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
 
 /** ListItem */
 const ListItem = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps,  children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <List.Item
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/menu/Menu.tsx
+++ b/src/ts/components/core/menu/Menu.tsx
@@ -37,15 +37,15 @@ interface Props extends __PopoverProps, StylesApiProps {
     setProps: (props: Record<string, any>) => void;
 }
 
-/** Menu */
+/** Use Menu to combine a list of secondary actions into single interactive area */
 const Menu = (props: Props) => {
     const { children, setProps, ...others } = props;
 
     return (
         <MantineMenu {...others}>
             {React.Children.map(children, (child: any, index) => {
-                const { type: childType, props: childProps } =
-                    child.props._dashprivate_layout;
+                const {type: childType, props: childProps} =
+                    window.dash_clientside.get_layout(child.props.componentPath);
                 if (childType === "MenuTarget") {
                     const { boxWrapperProps } = childProps;
                     return (

--- a/src/ts/components/core/menu/Menu.tsx
+++ b/src/ts/components/core/menu/Menu.tsx
@@ -62,6 +62,4 @@ const Menu = (props: Props) => {
     );
 };
 
-Menu.defaultProps = {};
-
 export default Menu;

--- a/src/ts/components/core/menu/MenuDivider.tsx
+++ b/src/ts/components/core/menu/MenuDivider.tsx
@@ -17,6 +17,4 @@ const MenuDivider = (props: Props) => {
     );
 };
 
-MenuDivider.defaultProps = {};
-
 export default MenuDivider;

--- a/src/ts/components/core/menu/MenuDivider.tsx
+++ b/src/ts/components/core/menu/MenuDivider.tsx
@@ -8,13 +8,10 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {}
 
 /** MenuDivider */
 const MenuDivider = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
 
     return (
         <Menu.Divider
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
             {...others}
         />
     );

--- a/src/ts/components/core/menu/MenuDropdown.tsx
+++ b/src/ts/components/core/menu/MenuDropdown.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** MenuDropdown */
 const MenuDropdown = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Menu.Dropdown
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/menu/MenuDropdown.tsx
+++ b/src/ts/components/core/menu/MenuDropdown.tsx
@@ -25,6 +25,4 @@ const MenuDropdown = (props: Props) => {
     );
 };
 
-MenuDropdown.defaultProps = {};
-
 export default MenuDropdown;

--- a/src/ts/components/core/menu/MenuItem.tsx
+++ b/src/ts/components/core/menu/MenuItem.tsx
@@ -38,7 +38,6 @@ const MenuItem = (props: Props) => {
         refresh,
         n_clicks,
         setProps,
-        loading_state,
         ...others
     } = props;
 
@@ -50,12 +49,13 @@ const MenuItem = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     if (href) {
         return (
             <Menu.Item
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined}
                 component="a"
                 onClick={(ev: MouseEvent<HTMLAnchorElement>) =>
                     onClick(ev, href, target, refresh)
@@ -71,9 +71,7 @@ const MenuItem = (props: Props) => {
     } else {
         return (
             <Menu.Item
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined}
                 onClick={increment}
                 disabled={disabled}
                 {...others}

--- a/src/ts/components/core/menu/MenuItem.tsx
+++ b/src/ts/components/core/menu/MenuItem.tsx
@@ -36,7 +36,7 @@ const MenuItem = (props: Props) => {
         href,
         target,
         refresh,
-        n_clicks,
+        n_clicks = 0,
         setProps,
         ...others
     } = props;
@@ -81,7 +81,5 @@ const MenuItem = (props: Props) => {
         );
     }
 };
-
-MenuItem.defaultProps = { n_clicks: 0 };
 
 export default MenuItem;

--- a/src/ts/components/core/menu/MenuLabel.tsx
+++ b/src/ts/components/core/menu/MenuLabel.tsx
@@ -25,6 +25,4 @@ const MenuLabel = (props: Props) => {
     );
 };
 
-MenuLabel.defaultProps = {};
-
 export default MenuLabel;

--- a/src/ts/components/core/menu/MenuLabel.tsx
+++ b/src/ts/components/core/menu/MenuLabel.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** MenuLabel */
 const MenuLabel = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Menu.Label
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/menu/MenuTarget.tsx
+++ b/src/ts/components/core/menu/MenuTarget.tsx
@@ -15,6 +15,4 @@ const MenuTarget = (props: Props) => {
     return <>{children}</>;
 };
 
-MenuTarget.defaultProps = {};
-
 export default MenuTarget;

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -7,7 +7,7 @@ interface Props extends PopoverProps, DashBaseProps {}
 
 /** The Popover component can be used to display additional content in a dropdown element, triggered by a user interaction with a target element. */
 const Popover = (props: Props) => {
-    const { children, opened, setProps, ...others } = props;
+    const { children, opened = false, setProps, ...others } = props;
     const ctx = (window as any).dash_component_api.useDashContext();
     const loading = ctx.useLoading();
 
@@ -40,10 +40,6 @@ const Popover = (props: Props) => {
             })}
         </MantinePopover>
     );
-};
-
-Popover.defaultProps = {
-    opened: false,
 };
 
 export default Popover;

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -19,17 +19,17 @@ const Popover = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const childType = child.props._dashprivate_layout.type;
+                const {type: childType, props: childProps} =
+                    window.dash_clientside.get_layout(child.props.componentPath);
 
                 if (childType === "PopoverTarget") {
-                    const { boxWrapperProps } = child.props;
-                    const boxProps = { w: "fit-content", ...boxWrapperProps };
+                    const { boxWrapperProps } = childProps;
 
                     return (
                         <MantinePopover.Target key={index}>
                             <Box
+                                w="fit-content" {...boxWrapperProps}
                                 onClick={() => setProps({ opened: !opened })}
-                                {...boxProps}
                             >
                                 {child}
                             </Box>

--- a/src/ts/components/core/popover/Popover.tsx
+++ b/src/ts/components/core/popover/Popover.tsx
@@ -7,13 +7,13 @@ interface Props extends PopoverProps, DashBaseProps {}
 
 /** The Popover component can be used to display additional content in a dropdown element, triggered by a user interaction with a target element. */
 const Popover = (props: Props) => {
-    const { children, opened, setProps, loading_state, ...others } = props;
+    const { children, opened, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantinePopover
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             opened={opened}
             onChange={(_opened) => !_opened && setProps({ opened: false })}
             {...others}

--- a/src/ts/components/core/popover/PopoverDropdown.tsx
+++ b/src/ts/components/core/popover/PopoverDropdown.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** PopoverDropdown */
 const PopoverDropdown = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Popover.Dropdown
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/popover/PopoverDropdown.tsx
+++ b/src/ts/components/core/popover/PopoverDropdown.tsx
@@ -25,6 +25,4 @@ const PopoverDropdown = (props: Props) => {
     );
 };
 
-PopoverDropdown.defaultProps = {};
-
 export default PopoverDropdown;

--- a/src/ts/components/core/popover/PopoverTarget.tsx
+++ b/src/ts/components/core/popover/PopoverTarget.tsx
@@ -15,6 +15,4 @@ const PopoverTarget = (props: Props) => {
     return <>{children}</>;
 };
 
-PopoverTarget.defaultProps = {};
-
 export default PopoverTarget;

--- a/src/ts/components/core/progress/Progress.tsx
+++ b/src/ts/components/core/progress/Progress.tsx
@@ -20,13 +20,13 @@ export interface Props
 
 /** Progress */
 const Progress = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineProgress
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/progress/Progress.tsx
+++ b/src/ts/components/core/progress/Progress.tsx
@@ -32,6 +32,4 @@ const Progress = (props: Props) => {
     );
 };
 
-Progress.defaultProps = {};
-
 export default Progress;

--- a/src/ts/components/core/progress/ProgressLabel.tsx
+++ b/src/ts/components/core/progress/ProgressLabel.tsx
@@ -11,13 +11,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** ProgressLabel */
 const ProgressLabel = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Progress.Label
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/progress/ProgressLabel.tsx
+++ b/src/ts/components/core/progress/ProgressLabel.tsx
@@ -23,6 +23,4 @@ const ProgressLabel = (props: Props) => {
     );
 };
 
-ProgressLabel.defaultProps = {};
-
 export default ProgressLabel;

--- a/src/ts/components/core/progress/ProgressRoot.tsx
+++ b/src/ts/components/core/progress/ProgressRoot.tsx
@@ -19,6 +19,4 @@ const ProgressRoot = (props: Props) => {
     );
 };
 
-ProgressRoot.defaultProps = {};
-
 export default ProgressRoot;

--- a/src/ts/components/core/progress/ProgressRoot.tsx
+++ b/src/ts/components/core/progress/ProgressRoot.tsx
@@ -7,13 +7,13 @@ export interface Props extends ProgressRootProps, DashBaseProps {}
 
 /** ProgressRoot */
 const ProgressRoot = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Progress.Root
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/progress/ProgressSection.tsx
+++ b/src/ts/components/core/progress/ProgressSection.tsx
@@ -21,13 +21,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** ProgressSection */
 const ProgressSection = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Progress.Section
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/core/progress/ProgressSection.tsx
+++ b/src/ts/components/core/progress/ProgressSection.tsx
@@ -33,6 +33,4 @@ const ProgressSection = (props: Props) => {
     );
 };
 
-ProgressSection.defaultProps = {};
-
 export default ProgressSection;

--- a/src/ts/components/core/radio/Radio.tsx
+++ b/src/ts/components/core/radio/Radio.tsx
@@ -46,8 +46,8 @@ const Radio = (props: Props) => {
     const {
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['checked'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -65,9 +65,5 @@ const Radio = (props: Props) => {
     );
 };
 
-Radio.defaultProps = {
-    persisted_props: ["checked"],
-    persistence_type: "local",
-};
 
 export default Radio;

--- a/src/ts/components/core/radio/Radio.tsx
+++ b/src/ts/components/core/radio/Radio.tsx
@@ -45,7 +45,6 @@ interface Props
 const Radio = (props: Props) => {
     const {
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -53,12 +52,12 @@ const Radio = (props: Props) => {
     } = props;
 
     const { radioOnClick } = React.useContext(RadioGroupContext) || {};
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineRadio
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={(ev) => setProps({ checked: ev.currentTarget.checked })}
             onClick={radioOnClick}
             {...others}

--- a/src/ts/components/core/radio/RadioGroup.tsx
+++ b/src/ts/components/core/radio/RadioGroup.tsx
@@ -28,8 +28,8 @@ const RadioGroup = (props: Props) => {
         value,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         deselectable,
         ...others
     } = props;
@@ -59,11 +59,6 @@ const RadioGroup = (props: Props) => {
             </RadioGroupContext.Provider>
         </Radio.Group>
     );
-};
-
-RadioGroup.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default RadioGroup;

--- a/src/ts/components/core/radio/RadioGroup.tsx
+++ b/src/ts/components/core/radio/RadioGroup.tsx
@@ -27,7 +27,6 @@ const RadioGroup = (props: Props) => {
         children,
         value,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -45,11 +44,12 @@ const RadioGroup = (props: Props) => {
         }
       };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <Radio.Group
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={onChange}
             value={value}
             {...others}

--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -64,7 +64,7 @@ interface Props
     /** Second thumb `aria-label` */
     thumbToLabel?: string;
     /** Determines when the component should update its value property. If mouseup (the default) then the Rangeslider will only trigger its value when the user has finished dragging the Rangeslider. If drag, then the Rangeslider will update its value continuously as it is being dragged. */
-    updatemode: "mouseup" | "drag";
+    updatemode?: "mouseup" | "drag";
 }
 
 /** RangeSlider */

--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -71,7 +71,6 @@ interface Props
 const RangeSlider = (props: Props) => {
     const {
         setProps,
-        loading_state,
         updatemode,
         value,
         persistence,
@@ -92,11 +91,12 @@ const RangeSlider = (props: Props) => {
         }
     }, [val]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineRangeSlider
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
             value={val}
             onChange={setVal}

--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -71,11 +71,11 @@ interface Props
 const RangeSlider = (props: Props) => {
     const {
         setProps,
-        updatemode,
+        updatemode = 'mouseup',
         value,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -107,12 +107,6 @@ const RangeSlider = (props: Props) => {
             }}
         />
     );
-};
-
-RangeSlider.defaultProps = {
-    updatemode: "mouseup",
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default RangeSlider;

--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -58,7 +58,7 @@ interface Props
     /** Determines whether track value representation should be inverted, `false` by default */
     inverted?: boolean;
     /** Determines when the component should update its value property. If mouseup (the default) then the slider will only trigger its value when the user has finished dragging the slider. If drag, then the slider will update its value continuously as it is being dragged. */
-    updatemode: "mouseup" | "drag";
+    updatemode?: "mouseup" | "drag";
     /** Determines whether the selection should be only allowed from the given marks array, false by default */
     restrictToMarks?: boolean;
 }

--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -67,7 +67,6 @@ interface Props
 const Slider = (props: Props) => {
     const {
         setProps,
-        loading_state,
         updatemode,
         value,
         persistence,
@@ -88,11 +87,12 @@ const Slider = (props: Props) => {
         }
     }, [val]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineSlider
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
             value={val}
             onChange={setVal}

--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -67,11 +67,11 @@ interface Props
 const Slider = (props: Props) => {
     const {
         setProps,
-        updatemode,
+        updatemode = 'mouseup',
         value,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -103,12 +103,6 @@ const Slider = (props: Props) => {
             }}
         />
     );
-};
-
-Slider.defaultProps = {
-    updatemode: "mouseup",
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default Slider;

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -66,7 +66,7 @@ const Stepper = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const childType = window.dash_clientside.get_layout(child.props.componentPath).type
+                const {type: childType, props: childProps} = window.dash_clientside.get_layout(child.props.componentPath);
                 if (childType === "StepperCompleted") {
                     return (
                         <MantineStepper.Completed>
@@ -74,7 +74,6 @@ const Stepper = (props: Props) => {
                         </MantineStepper.Completed>
                     );
                 } else {
-                    const childProps = window.dash_clientside.get_layout(child.props.componentPath).props
                     const renderedProps = renderDashComponents(
                         omit(["children"], childProps),
                         [

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -97,6 +97,4 @@ const Stepper = (props: Props) => {
     );
 };
 
-Stepper.defaultProps = {};
-
 export default Stepper;

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -66,7 +66,7 @@ const Stepper = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const childType = child.props._dashprivate_layout.type;
+                const childType = window.dash_clientside.get_layout(child.props.componentPath).type
                 if (childType === "StepperCompleted") {
                     return (
                         <MantineStepper.Completed>
@@ -74,7 +74,7 @@ const Stepper = (props: Props) => {
                         </MantineStepper.Completed>
                     );
                 } else {
-                    const childProps = child.props._dashprivate_layout.props;
+                    const childProps = window.dash_clientside.get_layout(child.props.componentPath).props
                     const renderedProps = renderDashComponents(
                         omit(["children"], childProps),
                         [

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -48,7 +48,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** Use Stepper to display content divided into a steps sequence */
 const Stepper = (props: Props) => {
-    const { setProps, loading_state, active, children, ...others } = props;
+    const { setProps, active, children, ...others } = props;
 
     const [act, setAct] = useState(active);
 
@@ -56,11 +56,12 @@ const Stepper = (props: Props) => {
         setAct(active);
     }, [active]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineStepper
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             active={act}
             onStepClick={(a) => setProps({active: a})}
             {...others}

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -46,7 +46,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
     children?: React.ReactNode;
 }
 
-/** Stepper */
+/** Use Stepper to display content divided into a steps sequence */
 const Stepper = (props: Props) => {
     const { setProps, loading_state, active, children, ...others } = props;
 

--- a/src/ts/components/core/stepper/StepperCompleted.tsx
+++ b/src/ts/components/core/stepper/StepperCompleted.tsx
@@ -12,6 +12,4 @@ const StepperCompleted = (props: Props) => {
     return <>{children}</>;
 };
 
-StepperCompleted.defaultProps = {};
-
 export default StepperCompleted;

--- a/src/ts/components/core/stepper/StepperStep.tsx
+++ b/src/ts/components/core/stepper/StepperStep.tsx
@@ -46,6 +46,4 @@ const StepperStep = (props: Props) => {
     return <>{children}</>;
 };
 
-StepperStep.defaultProps = {};
-
 export default StepperStep;

--- a/src/ts/components/core/stepper/StepperStep.tsx
+++ b/src/ts/components/core/stepper/StepperStep.tsx
@@ -41,7 +41,7 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** StepperStep */
 const StepperStep = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
 
     return <>{children}</>;
 };

--- a/src/ts/components/core/table/Table.tsx
+++ b/src/ts/components/core/table/Table.tsx
@@ -46,13 +46,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Table */
 const Table = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineTable
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/table/Table.tsx
+++ b/src/ts/components/core/table/Table.tsx
@@ -60,6 +60,4 @@ const Table = (props: Props) => {
     );
 };
 
-Table.defaultProps = {};
-
 export default Table;

--- a/src/ts/components/core/table/TableCaption.tsx
+++ b/src/ts/components/core/table/TableCaption.tsx
@@ -8,6 +8,4 @@ const TableCaption = (props: TableElementProps) => {
     return <Table.Caption {...others}>{children}</Table.Caption>;
 };
 
-TableCaption.defaultProps = {};
-
 export default TableCaption;

--- a/src/ts/components/core/table/TableTbody.tsx
+++ b/src/ts/components/core/table/TableTbody.tsx
@@ -8,6 +8,4 @@ const TableTbody = (props: TableElementProps) => {
     return <Table.Tbody {...others}>{children}</Table.Tbody>;
 };
 
-TableTbody.defaultProps = {};
-
 export default TableTbody;

--- a/src/ts/components/core/table/TableTd.tsx
+++ b/src/ts/components/core/table/TableTd.tsx
@@ -8,6 +8,4 @@ const TableTd = (props: TableElementProps) => {
     return <Table.Td {...others}>{children}</Table.Td>;
 };
 
-TableTd.defaultProps = {};
-
 export default TableTd;

--- a/src/ts/components/core/table/TableTfoot.tsx
+++ b/src/ts/components/core/table/TableTfoot.tsx
@@ -8,6 +8,4 @@ const TableTfoot = (props: TableElementProps) => {
     return <Table.Tfoot {...others}>{children}</Table.Tfoot>;
 };
 
-TableTfoot.defaultProps = {};
-
 export default TableTfoot;

--- a/src/ts/components/core/table/TableTh.tsx
+++ b/src/ts/components/core/table/TableTh.tsx
@@ -8,6 +8,4 @@ const TableTh = (props: TableElementProps) => {
     return <Table.Th {...others}>{children}</Table.Th>;
 };
 
-TableTh.defaultProps = {};
-
 export default TableTh;

--- a/src/ts/components/core/table/TableThead.tsx
+++ b/src/ts/components/core/table/TableThead.tsx
@@ -8,6 +8,4 @@ const TableThead = (props: TableElementProps) => {
     return <Table.Thead {...others}>{children}</Table.Thead>;
 };
 
-TableThead.defaultProps = {};
-
 export default TableThead;

--- a/src/ts/components/core/table/TableTr.tsx
+++ b/src/ts/components/core/table/TableTr.tsx
@@ -8,6 +8,4 @@ const TableTr = (props: TableElementProps) => {
     return <Table.Tr {...others}>{children}</Table.Tr>;
 };
 
-TableTr.defaultProps = {};
-
 export default TableTr;

--- a/src/ts/components/core/tabs/Tabs.tsx
+++ b/src/ts/components/core/tabs/Tabs.tsx
@@ -47,8 +47,8 @@ const Tabs = (props: Props) => {
         children,
         setProps,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -67,11 +67,6 @@ const Tabs = (props: Props) => {
             {children}
         </MantineTabs>
     );
-};
-
-Tabs.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
 };
 
 export default Tabs;

--- a/src/ts/components/core/tabs/Tabs.tsx
+++ b/src/ts/components/core/tabs/Tabs.tsx
@@ -46,7 +46,6 @@ const Tabs = (props: Props) => {
     const {
         children,
         setProps,
-        loading_state,
         persistence,
         persisted_props,
         persistence_type,
@@ -56,12 +55,12 @@ const Tabs = (props: Props) => {
     const onChange = (value: string) => {
         setProps({ value });
     };
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineTabs
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={onChange}
             {...others}
         >

--- a/src/ts/components/core/tabs/TabsList.tsx
+++ b/src/ts/components/core/tabs/TabsList.tsx
@@ -29,6 +29,4 @@ const TabsList = (props: Props) => {
     );
 };
 
-TabsList.defaultProps = {};
-
 export default TabsList;

--- a/src/ts/components/core/tabs/TabsList.tsx
+++ b/src/ts/components/core/tabs/TabsList.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** TabsList */
 const TabsList = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Tabs.List
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/tabs/TabsPanel.tsx
+++ b/src/ts/components/core/tabs/TabsPanel.tsx
@@ -29,6 +29,4 @@ const TabsPanel = (props: Props) => {
     );
 };
 
-TabsPanel.defaultProps = {};
-
 export default TabsPanel;

--- a/src/ts/components/core/tabs/TabsPanel.tsx
+++ b/src/ts/components/core/tabs/TabsPanel.tsx
@@ -15,13 +15,13 @@ interface Props extends BoxProps, DashBaseProps, StylesApiProps {
 
 /** TabsPanel */
 const TabsPanel = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Tabs.Panel
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/tabs/TabsTab.tsx
+++ b/src/ts/components/core/tabs/TabsTab.tsx
@@ -25,13 +25,13 @@ interface Props
 
 /** TabsTab */
 const TabsTab = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Tabs.Tab
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}

--- a/src/ts/components/core/tabs/TabsTab.tsx
+++ b/src/ts/components/core/tabs/TabsTab.tsx
@@ -39,6 +39,4 @@ const TabsTab = (props: Props) => {
     );
 };
 
-TabsTab.defaultProps = {};
-
 export default TabsTab;

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -33,13 +33,13 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Use the Timeline and TimelineItem components to display a list of events in chronological order. */
 const Timeline = (props: Props) => {
-    const { setProps, loading_state, children, ...others } = props;
+    const { setProps, children, ...others } = props;
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineTimeline
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -43,7 +43,8 @@ const Timeline = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const childProps = child.props._dashprivate_layout.props;
+                const childProps = window.dash_clientside.get_props(child.props.componentPath)
+
                 const renderedProps = renderDashComponents(
                     omit(["children"], childProps),
                     ["title", "bullet"]

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -31,7 +31,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     autoContrast?: boolean;
 }
 
-/** Timeline */
+/** Use the Timeline and TimelineItem components to display a list of events in chronological order. */
 const Timeline = (props: Props) => {
     const { setProps, loading_state, children, ...others } = props;
 

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -59,6 +59,4 @@ const Timeline = (props: Props) => {
     );
 };
 
-Timeline.defaultProps = {};
-
 export default Timeline;

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -43,7 +43,7 @@ const Timeline = (props: Props) => {
             {...others}
         >
             {React.Children.map(children, (child: any, index) => {
-                const childProps = window.dash_clientside.get_props(child.props.componentPath)
+                const childProps = window.dash_clientside.get_layout(child.props.componentPath).props
 
                 const renderedProps = renderDashComponents(
                     omit(["children"], childProps),

--- a/src/ts/components/core/timeline/TimelineItem.tsx
+++ b/src/ts/components/core/timeline/TimelineItem.tsx
@@ -19,7 +19,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** TimelineItem */
 const TimelineItem = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
 
     return <>{children}</>;
 };

--- a/src/ts/components/core/timeline/TimelineItem.tsx
+++ b/src/ts/components/core/timeline/TimelineItem.tsx
@@ -24,6 +24,4 @@ const TimelineItem = (props: Props) => {
     return <>{children}</>;
 };
 
-TimelineItem.defaultProps = {};
-
 export default TimelineItem;

--- a/src/ts/components/core/tooltip/FloatingTooltip.tsx
+++ b/src/ts/components/core/tooltip/FloatingTooltip.tsx
@@ -13,15 +13,15 @@ interface Props extends TooltipBaseProps, DashBaseProps {
 
 /** FloatingTooltip */
 const FloatingTooltip = (props: Props) => {
-    const { children, boxWrapperProps, setProps, loading_state, ...others } =
-        props;
+    const { children, boxWrapperProps, setProps, ...others } = props;
     const boxProps = { w: "fit-content", key: "tooltip-target", ...boxWrapperProps };
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Tooltip.Floating
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             <Box {...boxProps}>{children}</Box>

--- a/src/ts/components/core/tooltip/FloatingTooltip.tsx
+++ b/src/ts/components/core/tooltip/FloatingTooltip.tsx
@@ -29,6 +29,4 @@ const FloatingTooltip = (props: Props) => {
     );
 };
 
-FloatingTooltip.defaultProps = {};
-
 export default FloatingTooltip;

--- a/src/ts/components/core/tooltip/Tooltip.tsx
+++ b/src/ts/components/core/tooltip/Tooltip.tsx
@@ -52,15 +52,14 @@ interface Props extends TooltipBaseProps, DashBaseProps {
 
 /** Tooltip */
 const Tooltip = (props: Props) => {
-    const { children, boxWrapperProps, setProps, loading_state, ...others } =
-        props;
+    const { children, boxWrapperProps, setProps, ...others } = props;
     const boxProps = { w: "fit-content", key: "tooltip-target", ...boxWrapperProps };
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineTooltip
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             <Box {...boxProps}>{children}</Box>

--- a/src/ts/components/core/tooltip/Tooltip.tsx
+++ b/src/ts/components/core/tooltip/Tooltip.tsx
@@ -67,6 +67,4 @@ const Tooltip = (props: Props) => {
     );
 };
 
-Tooltip.defaultProps = {};
-
 export default Tooltip;

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -58,7 +58,6 @@ interface Props
 const DateInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         n_submit,
         n_blur,
         value,
@@ -117,12 +116,13 @@ const DateInput = (props: Props) => {
         return isDisabled(date, disabledDates || []);
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <div ref={ref}>
             <MantineDateInput
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined }
                 onBlur={handleBlur}
                 onKeyDown={handleKeyDown}
                 onChange={setDate}

--- a/src/ts/components/dates/DateInput.tsx
+++ b/src/ts/components/dates/DateInput.tsx
@@ -58,16 +58,16 @@ interface Props
 const DateInput = (props: Props) => {
     const {
         setProps,
-        n_submit,
-        n_blur,
+        n_submit = 0,
+        n_blur = 0,
         value,
-        debounce,
+        debounce = false,
         minDate,
         maxDate,
         disabledDates,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -134,14 +134,6 @@ const DateInput = (props: Props) => {
             />
         </div>
     );
-};
-
-DateInput.defaultProps = {
-    debounce: false,
-    persisted_props: ["value"],
-    persistence_type: "local",
-    n_submit: 0,
-    n_blur: 0,
 };
 
 export default DateInput;

--- a/src/ts/components/dates/DatePickerInput.tsx
+++ b/src/ts/components/dates/DatePickerInput.tsx
@@ -33,7 +33,6 @@ interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputShar
 const DatePickerInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         n_submit,
         type,
         value,
@@ -87,12 +86,13 @@ const DatePickerInput = (props: Props) => {
 
     const isExcluded = (date: Date) => isDisabled(date, disabledDates || []);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <div ref={ref}>
             <MantineDatePickerInput
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
+                data-dash-is-loading={loading || undefined}
                 onBlur={handleBlur}
                 onKeyDown={handleKeyDown}
                 onChange={setDate}

--- a/src/ts/components/dates/DatePickerInput.tsx
+++ b/src/ts/components/dates/DatePickerInput.tsx
@@ -33,16 +33,16 @@ interface Props extends DashBaseProps, PersistenceProps, BoxProps, DateInputShar
 const DatePickerInput = (props: Props) => {
     const {
         setProps,
-        n_submit,
-        type,
+        n_submit = 0,
+        type = 'default',
         value,
-        debounce,
+        debounce = false,
         minDate,
         maxDate,
         disabledDates,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -105,14 +105,6 @@ const DatePickerInput = (props: Props) => {
             />
         </div>
     );
-};
-
-DatePickerInput.defaultProps = {
-    persisted_props: ['value'],
-    persistence_type: 'local',
-    debounce: 0,
-    n_submit: 0,
-    type: 'default',
 };
 
 export default DatePickerInput;

--- a/src/ts/components/dates/DateTimePicker.tsx
+++ b/src/ts/components/dates/DateTimePicker.tsx
@@ -48,7 +48,6 @@ interface Props
 const DateTimePicker = (props: Props) => {
     const {
         setProps,
-        loading_state,
         value,
         debounce,
         n_submit,
@@ -82,11 +81,12 @@ const DateTimePicker = (props: Props) => {
         }
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineDateTimePicker
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onChange={setDate}
             value={date}
             onKeyDown={handleKeyDown}

--- a/src/ts/components/dates/DateTimePicker.tsx
+++ b/src/ts/components/dates/DateTimePicker.tsx
@@ -49,14 +49,14 @@ const DateTimePicker = (props: Props) => {
     const {
         setProps,
         value,
-        debounce,
-        n_submit,
+        debounce = 0,
+        n_submit = 0,
         minDate,
         maxDate,
         disabledDates,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -96,13 +96,6 @@ const DateTimePicker = (props: Props) => {
             {...others}
         />
     );
-};
-
-DateTimePicker.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    debounce: 0,
-    n_submit: 0,
 };
 
 export default DateTimePicker;

--- a/src/ts/components/dates/DatesProvider.tsx
+++ b/src/ts/components/dates/DatesProvider.tsx
@@ -35,6 +35,4 @@ const DatesProvider = (props: Props) => {
     );
 };
 
-DatesProvider.defaultProps = {};
-
 export default DatesProvider;

--- a/src/ts/components/dates/MonthPickerInput.tsx
+++ b/src/ts/components/dates/MonthPickerInput.tsx
@@ -33,7 +33,6 @@ interface Props
 const MonthPickerInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         n_submit,
         value,
         type,
@@ -68,11 +67,12 @@ const MonthPickerInput = (props: Props) => {
         return isDisabled(date, disabledDates || []);
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineMonthPickerInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/dates/MonthPickerInput.tsx
+++ b/src/ts/components/dates/MonthPickerInput.tsx
@@ -33,16 +33,16 @@ interface Props
 const MonthPickerInput = (props: Props) => {
     const {
         setProps,
-        n_submit,
+        n_submit = 0,
         value,
         type,
-        debounce,
+        debounce = 0,
         minDate,
         maxDate,
         disabledDates,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -83,13 +83,6 @@ const MonthPickerInput = (props: Props) => {
             {...others}
         />
     );
-};
-
-MonthPickerInput.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    debounce: 0,
-    n_submit: 0,
 };
 
 export default MonthPickerInput;

--- a/src/ts/components/dates/TimeInput.tsx
+++ b/src/ts/components/dates/TimeInput.tsx
@@ -24,7 +24,6 @@ interface Props
 const TimeInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         n_submit,
         n_blur,
         value,
@@ -66,11 +65,12 @@ const TimeInput = (props: Props) => {
         });
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineTimeInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             onChange={(ev) => setTime(ev.currentTarget.value)}

--- a/src/ts/components/dates/TimeInput.tsx
+++ b/src/ts/components/dates/TimeInput.tsx
@@ -24,13 +24,13 @@ interface Props
 const TimeInput = (props: Props) => {
     const {
         setProps,
-        n_submit,
-        n_blur,
-        value,
-        debounce,
+        n_submit = 0,
+        n_blur = 0,
+        value = '',
+        debounce = false,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -80,13 +80,5 @@ const TimeInput = (props: Props) => {
     );
 };
 
-TimeInput.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    debounce: false,
-    n_submit: 0,
-    n_blur: 0,
-    value: "",
-};
 
 export default TimeInput;

--- a/src/ts/components/dates/YearPickerInput.tsx
+++ b/src/ts/components/dates/YearPickerInput.tsx
@@ -33,7 +33,6 @@ interface Props
 const YearPickerInput = (props: Props) => {
     const {
         setProps,
-        loading_state,
         n_submit,
         value,
         type,
@@ -68,11 +67,12 @@ const YearPickerInput = (props: Props) => {
         return isDisabled(date, disabledDates || []);
     };
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineYearPickerInput
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             wrapperProps={{ autoComplete: "off" }}
             onKeyDown={handleKeyDown}
             onChange={setDate}

--- a/src/ts/components/dates/YearPickerInput.tsx
+++ b/src/ts/components/dates/YearPickerInput.tsx
@@ -33,16 +33,16 @@ interface Props
 const YearPickerInput = (props: Props) => {
     const {
         setProps,
-        n_submit,
+        n_submit = 0,
         value,
         type,
-        debounce,
+        debounce = 0,
         minDate,
         maxDate,
         disabledDates,
         persistence,
-        persisted_props,
-        persistence_type,
+        persisted_props = ['value'],
+        persistence_type = 'local',
         ...others
     } = props;
 
@@ -85,11 +85,5 @@ const YearPickerInput = (props: Props) => {
     );
 };
 
-YearPickerInput.defaultProps = {
-    persisted_props: ["value"],
-    persistence_type: "local",
-    debounce: 0,
-    n_submit: 0,
-};
 
 export default YearPickerInput;

--- a/src/ts/components/extensions/carousel/Carousel.tsx
+++ b/src/ts/components/extensions/carousel/Carousel.tsx
@@ -64,7 +64,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Carousel */
 const Carousel = (props: Props) => {
-    const { children, active, initialSlide, setProps, autoplay, autoScroll, ...others } = props;
+    const { children, active = 0, initialSlide = 0, setProps, autoplay, autoScroll, ...others } = props;
 
     const autoplayPlugin =
         autoplay === true
@@ -100,9 +100,5 @@ const Carousel = (props: Props) => {
     );
 };
 
-Carousel.defaultProps = {
-    initialSlide:0,
-    active:0
-};
 
 export default Carousel;

--- a/src/ts/components/extensions/carousel/Carousel.tsx
+++ b/src/ts/components/extensions/carousel/Carousel.tsx
@@ -64,7 +64,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** Carousel */
 const Carousel = (props: Props) => {
-    const { children, active, initialSlide, setProps, loading_state, autoplay, autoScroll, ...others } = props;
+    const { children, active, initialSlide, setProps, autoplay, autoScroll, ...others } = props;
 
     const autoplayPlugin =
         autoplay === true
@@ -84,11 +84,12 @@ const Carousel = (props: Props) => {
          setProps({active: initialSlide})
      }, [initialSlide]);
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineCarousel
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
             plugins={[autoplayPlugin, autoScrollPlugin].filter(Boolean)}
             onSlideChange={(a) => setProps({ active: a ?? initialSlide })}

--- a/src/ts/components/extensions/carousel/CarouselSlide.tsx
+++ b/src/ts/components/extensions/carousel/CarouselSlide.tsx
@@ -27,6 +27,4 @@ const CarouselSlide = (props: Props) => {
     );
 };
 
-CarouselSlide.defaultProps = {};
-
 export default CarouselSlide;

--- a/src/ts/components/extensions/carousel/CarouselSlide.tsx
+++ b/src/ts/components/extensions/carousel/CarouselSlide.tsx
@@ -11,13 +11,15 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CarouselSlide */
 const CarouselSlide = (props: Props) => {
-    const { children, setProps, loading_state, ...others } = props;
+    const { children, setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
 
     return (
         <Carousel.Slide
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         >
             {children}{" "}

--- a/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
@@ -34,6 +34,4 @@ const CodeHighlight = (props: Props) => {
     );
 };
 
-CodeHighlight.defaultProps = {};
-
 export default CodeHighlight;

--- a/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlight.tsx
@@ -21,13 +21,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CodeHighlight */
 const CodeHighlight = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <MantineCodeHighlight
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
@@ -58,6 +58,4 @@ const CodeHighlightTabs = (props: Props) => {
     );
 };
 
-CodeHighlightTabs.defaultProps = {};
-
 export default CodeHighlightTabs;

--- a/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
@@ -36,7 +36,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** CodeHighlightTabs */
 const CodeHighlightTabs = (props: Props) => {
-    const { setProps, loading_state, code, ...others } = props;
+    const { setProps,  code, ...others } = props;
     const renderedCode = [];
     if (Array.isArray(code)) {
         code.forEach((item, index) => {
@@ -46,11 +46,12 @@ const CodeHighlightTabs = (props: Props) => {
         renderedCode.push(renderDashComponents(code, ["icon"]));
     }
 
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
+
     return (
         <MantineCodeHighlightTabs
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             code={renderedCode}
             {...others}
         />

--- a/src/ts/components/extensions/notifications/Notification.tsx
+++ b/src/ts/components/extensions/notifications/Notification.tsx
@@ -39,7 +39,7 @@ interface Props extends BoxProps, StylesApiProps, Omit<DashBaseProps, "id"> {
 
 /** Notification */
 const Notification = (props: Props) => {
-    const { action, setProps, loading_state, ...others } = props;
+    const { action, setProps,  ...others } = props;
 
     useEffect(() => {
         switch (action) {

--- a/src/ts/components/extensions/notifications/Notification.tsx
+++ b/src/ts/components/extensions/notifications/Notification.tsx
@@ -69,6 +69,4 @@ const Notification = (props: Props) => {
     }, [props]);
 };
 
-Notification.defaultProps = {};
-
 export default Notification;

--- a/src/ts/components/extensions/notifications/NotificationProvider.tsx
+++ b/src/ts/components/extensions/notifications/NotificationProvider.tsx
@@ -31,13 +31,14 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 
 /** NotificationProvider */
 const NotificationProvider = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps,  ...others } = props;
+
+    const ctx = (window as any).dash_component_api.useDashContext();
+    const loading = ctx.useLoading();
 
     return (
         <Notifications
-            data-dash-is-loading={
-                (loading_state && loading_state.is_loading) || undefined
-            }
+            data-dash-is-loading={loading || undefined}
             {...others}
         />
     );

--- a/src/ts/components/extensions/notifications/NotificationProvider.tsx
+++ b/src/ts/components/extensions/notifications/NotificationProvider.tsx
@@ -44,6 +44,4 @@ const NotificationProvider = (props: Props) => {
     );
 };
 
-NotificationProvider.defaultProps = {};
-
 export default NotificationProvider;

--- a/src/ts/components/extensions/nprogress/NavigationProgress.tsx
+++ b/src/ts/components/extensions/nprogress/NavigationProgress.tsx
@@ -34,6 +34,5 @@ const NavigationProgress = (props: Props) => {
     }, [props]);
 };
 
-NavigationProgress.defaultProps = {};
 
 export default NavigationProgress;

--- a/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
+++ b/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
@@ -20,7 +20,7 @@ interface Props extends DashBaseProps {
 
 /** NavigationProgressProvider */
 const NavigationProgressProvider = (props: Props) => {
-    const { setProps, loading_state, ...others } = props;
+    const { setProps, ...others } = props;
 
     return <NavigationProgress {...others} />;
 };

--- a/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
+++ b/src/ts/components/extensions/nprogress/NavigationProgressProvider.tsx
@@ -25,6 +25,4 @@ const NavigationProgressProvider = (props: Props) => {
     return <NavigationProgress {...others} />;
 };
 
-NavigationProgressProvider.defaultProps = {};
-
 export default NavigationProgressProvider;

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -20,6 +20,4 @@ const MantineProvider = (props: Props) => {
     );
 };
 
-MantineProvider.defaultProps = {};
-
 export default MantineProvider;

--- a/src/ts/global.d.ts
+++ b/src/ts/global.d.ts
@@ -1,0 +1,12 @@
+export {};
+
+declare global {
+    interface Window {
+        dash_clientside: {
+            get_props: (
+                componentPathOrId: string | string[],
+                ...propPath: string[]
+            ) => any;
+        };
+    }
+}

--- a/src/ts/global.d.ts
+++ b/src/ts/global.d.ts
@@ -1,12 +1,10 @@
+// global.d.ts
 export {};
 
 declare global {
     interface Window {
         dash_clientside: {
-            get_props: (
-                componentPathOrId: string | string[],
-                ...propPath: string[]
-            ) => any;
+            get_layout: (componentPathOrId: string | string[]) => any;
         };
     }
 }

--- a/src/ts/props/dash.ts
+++ b/src/ts/props/dash.ts
@@ -9,15 +9,6 @@ export interface DashBaseProps {
     "aria-*"?: string;
     /** tab-index */
     tabIndex?: number;
-    /**  Object that holds the loading state object coming from dash-renderer  */
-    loading_state?: {
-        /** Determines if the component is loading or not */
-        is_loading: boolean;
-        /** Holds which property is loading */
-        prop_name: string;
-        /** Holds the name of the component that is loading */
-        component_name: string;
-    };
 }
 
 export interface PersistenceProps {


### PR DESCRIPTION
### Note:  This PR will be closed in favor of #499


Close #453 

When updates were made in [Dash PR#3066  ](https://github.com/plotly/dash/pull/3066) to address  #390, `_dashprivate` props were removed.  This PR updates to remove these props from dmc.  Also loading state coming from the dash render has changed.

- [x] Checkbox - update function to handle custom icons in checkboxes
- [x] Popover
- [x] Menu
- [x] Hovercard
- [x] Timeline
- [x] Stepper
- [x]  Anchor - This component uses `_dashprivate_pushstate`.  Confirmed that it's OK to use this private variable.  It enables the `dmc.Anchor` to work like the `dcc.Link` component with the `dcc.Location` component.  See [3066 comment](https://github.com/plotly/dash/pull/3066#issuecomment-2546077821)
- [ ] Skeleton.  This component works when you manually set the `visible` prop, but does not automatically update based on the loading status of it's children.  Would probably need to add logic similar to the dcc.Loading component.
- [x] Check on the use of [`renderDashComponents` ](https://github.com/emilhe/dash-extensions-js/blob/8b07ce3b61bbd3150cbf8dd6c5fb6d0204e74adf/index.js#L372) function and see if there is a better way.  It's used in these  [4 components](https://github.com/search?q=repo%3Asnehilvj%2Fdash-mantine-components+renderDash&type=code) .  See [this comment](https://github.com/plotly/dash/pull/3066#issuecomment-2545768188) in Dash PR.  Chatted with Philippe and he mentioned that he could add `render(component, path)` to `dash_component_api` quite easily, but it would be in a release after Dash 3.0.  I verified that the 4 components using `renderDashComponents` still works with Dash PR 3066.


- [x] Dash 3 uses React 18.3.1 which no longer supports `defaultProps`.  Need to update every component and test the docs app with React 18.3.1.  Updated all but `Drawer` and `Modal`
- [ ] Can't set defaults on required props without `defaultProps`.  Affects `Drawer`, `Modal`,

- [ ] Update new components after they are merged:  `Tree`  `InlineCodeHighlight`
- [ ] See [this comment](https://github.com/plotly/dash/pull/3066#discussion_r1928923549) about setting default props for persistence 
- [ ] Update `get_layout`  See [this comment](https://github.com/plotly/dash/pull/3066#issuecomment-2612884559)


For setting defaults on required types in Mantine try:
> set it to Partial<MantineProps> and all the props would be optional, if only want some types can take those props and the rest as is.

Note - Test pass locally when using the dash version from PR 3066
