### PR TITLE
add new props available in 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,22 @@
 
 # 0.15.2
 
-
 ### Added
 - Added `disabled` prop for individual options on a `SegmentedControl`  #451  by @petefine 
-- Added `type` prop for `SimpleGrid` #472 by @namakshenas
-- Added `type` prop and `breakpoints` prop for `Grid` #473 by @namakshenas
-- Added props:
+- Added `type` prop for `SimpleGrid` to enable container queries #472 by @namakshenas
+- Added `type` prop and `breakpoints` prop for `Grid` to enable container queries #473 by @namakshenas
+- Added props #478 by @AnnMarieW:
     - `inline` prop to `Center`, 
     - `allowedInitialsColors` to `Avatar`
     - `defaultExpanded` to `CodeHightlightTabs`
     - `autoComplete` to `PasswordInput`
-  #478 by @AnnMarieW
+  
+- Added props available in Mantine 7.16.0 #489 by @AnnMarieW
+    - `withOverlay` and `overlayProps` to `Popover
+    - `withPages` to `Pagination
+    - `type` to `Carousel` enabling container queries
+    - `restrictToMarks` to `RangeSlider`
+  
 
 - Added `Tree` component #460 by @Godisemo
 - Added `InlineCodeHighlight` component #483 by @Godisemo
@@ -20,8 +25,6 @@
 ### Fixed
 - Styled the figure buttons in the "mantine_light" and "mantine_dark" Plotly figure templates.  #456 by @AnnMarieW
 - In `Carousel`  Allow only "center" | "start" | "end" in the `align` prop #477 by @AnnMarieW
-
-
 
 ### Changed
 - Upgraded to latest Mantine (7.16.1)

--- a/src/ts/components/core/Pagination.tsx
+++ b/src/ts/components/core/Pagination.tsx
@@ -40,6 +40,8 @@ interface Props
     autoContrast?: boolean;
     /** Determines whether the pagination should be hidden when only one page is available (total=1), False by default */
     hideWithOnePage?: boolean;
+    /** Determines whether pages controls should be displayed, `true` by default */
+    withPages?: boolean;
 }
 
 /** Use the Pagination component to display active page and navigate between multiple pages */

--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -65,6 +65,8 @@ interface Props
     thumbToLabel?: string;
     /** Determines when the component should update its value property. If mouseup (the default) then the Rangeslider will only trigger its value when the user has finished dragging the Rangeslider. If drag, then the Rangeslider will update its value continuously as it is being dragged. */
     updatemode: "mouseup" | "drag";
+    /** Determines whether the selection should be only allowed from the given marks array, false by default */
+    restrictToMarks?: boolean;
 }
 
 /** RangeSlider */

--- a/src/ts/components/extensions/carousel/Carousel.tsx
+++ b/src/ts/components/extensions/carousel/Carousel.tsx
@@ -60,6 +60,8 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     autoplay?: boolean | Record<string, any>;
     /** Enables autoScroll with optional configuration */
     autoScroll?: boolean | Record<string, any>;
+    /** Determines typeof of queries that are used for responsive styles, 'media' by default */
+    type?: "media" | "container";
 }
 
 /** Carousel */

--- a/src/ts/props/popover.ts
+++ b/src/ts/props/popover.ts
@@ -52,6 +52,10 @@ export interface __PopoverProps {
     returnFocus?: boolean;
     /** Changes floating ui [position strategy](https://floating-ui.com/docs/usefloating#strategy), `'absolute'` by default */
     floatingStrategy?: FloatingStrategy;
+    /** Props passed down to `Overlay` component */
+    overlayProps?: object;
+    /** Determines whether the overlay should be displayed when the dropdown is opened, `false` by default */
+    withOverlay?: boolean;
 }
 
 export interface PopoverProps extends __PopoverProps, StylesApiProps {


### PR DESCRIPTION
Added props available in Mantine 7.16.0 release https://mantine.dev/changelog/7-16-0/


- `withOverlay` and `overlayProps` to `Popover
 - `withPages` to `Pagination
 - `type` to `Carousel` to enable container queries
 - `restrictToMarks` to `RangeSlider`

Examples of each available in  the docs PR:  dmc-docs PR https://github.com/snehilvj/dmc-docs/pull/148