### PR TITLE
Fix debounce by updating popover returnFocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+
+# Unreleased
+
+### Fixed
+
+- fixed debounce on DatePickerInput that stopped working in 0.15.2  #496 by @AnnMarie
+
 # 0.15.2
 
 ### Added

--- a/src/ts/components/dates/DatePickerInput.tsx
+++ b/src/ts/components/dates/DatePickerInput.tsx
@@ -101,6 +101,7 @@ const DatePickerInput = (props: Props) => {
                 minDate={stringToDate(minDate)}
                 maxDate={stringToDate(maxDate)}
                 excludeDate={isExcluded}
+                popoverProps={{returnFocus: true}}
                 {...others}
             />
         </div>

--- a/src/ts/components/dates/DatePickerInput.tsx
+++ b/src/ts/components/dates/DatePickerInput.tsx
@@ -41,6 +41,7 @@ const DatePickerInput = (props: Props) => {
         minDate,
         maxDate,
         disabledDates,
+        popoverProps,
         persistence,
         persisted_props,
         persistence_type,
@@ -101,7 +102,7 @@ const DatePickerInput = (props: Props) => {
                 minDate={stringToDate(minDate)}
                 maxDate={stringToDate(maxDate)}
                 excludeDate={isExcluded}
-                popoverProps={{returnFocus: true}}
+                popoverProps={{returnFocus: true, ...popoverProps}}
                 {...others}
             />
         </div>


### PR DESCRIPTION
closes #495 

When `debounce=True`, the value is updated when the input loses focus.  

In a recent [Mantine update](https://github.com/mantinedev/mantine/commit/7dbda1e6f2c95aaf1e52251b1874c15de2e59872#diff-8e830fef686217ced24afe002b543505b26c944ca69a51d5b840e156664304f1R164), they changed the default popover prop  `returnFocus` to false,  which meant that the Input wasn't focused after the dates were selected.  This broke the debounce because it wasn't possible to update the value when the input loses focus. 


```python
import dash_mantine_components as dmc
from dash import Dash, _dash_renderer, Input, Output, html, callback
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

from datetime import datetime, date, timedelta


component = html.Div(
    [
        dmc.DatePickerInput(
            id="date-picker-input-multiple",
            label="Pick dates",
            description="Pick one or more dates",
            minDate=date(2020, 8, 5),
            value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
            w=400,
            type="multiple",
            placeholder="Pick dates",
            maw=300,
            clearable=True,
            debounce=True,
        #    popoverProps={"returnFocus": True}   # this was required in order for the debounce to work in 0.15.2
        ),
        dmc.Space(h=10),
        dmc.Text(id="selected-date-input-multiple"),
    ]
)


@callback(
    Output("selected-date-input-multiple", "children"),
    Input("date-picker-input-multiple", "value"),
)
def update_output(dates):
    return str(dates)

app.layout = dmc.MantineProvider(
    component
)

if __name__ == "__main__":
    app.run(debug=True)




```