### PR TITLE
NavLink Update for Active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+# Unreleased
+
+### Added
+- Added `CheckboxCard` `CheckboxIndicator` `RadioCard` `RadioIndicator` components #486 by @deadkex
+
+### Changed
+- Expanded the `active` prop to support string values (`"exact"` and `"partial"`) in addition to `true`/`false`. #504 by @BSd3v
+  - `exact`: Marks the link as active only when `pathname` exactly matches `href`.
+  - `partial`: Marks the link as active when `pathname` starts with `href`, allowing for subpages.
+
+
 # 1.0.0rc1
 
 ###  Pre-release Highlights
@@ -7,10 +18,6 @@
 - If you were using `dmc >= 0.15.0`, there are no known breaking change.
 - If you were using `dmc < 0.15.0`, please follow our [migration guide](https://www.dash-mantine-components.com/migration).
 - ⚠️ **Important:** Apps using `dmc < 1.0.0` must pin `dash < 3` to avoid compatibility issues.
-
-### Added
-
--   Added `CheckboxCard` `CheckboxIndicator` `RadioCard` `RadioIndicator` components #486 by @deadkex
 
 ### Changed
 - Updated to handle changes in Dash 3 #506 by @AnnMarieW:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@mantine/notifications": "7.16.2",
                 "@mantine/nprogress": "7.16.2",
                 "@mantine/spotlight": "7.16.2",
+                "@plotly/dash-component-plugins": "^1.2.0",
                 "dayjs": "^1.11.10",
                 "embla-carousel-auto-scroll": "^8.4.0",
                 "embla-carousel-autoplay": "^8.4.0",
@@ -614,6 +615,12 @@
             "peerDependencies": {
                 "react": "^18.x || ^19.x"
             }
+        },
+        "node_modules/@plotly/dash-component-plugins": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@plotly/dash-component-plugins/-/dash-component-plugins-1.2.3.tgz",
+            "integrity": "sha512-BjcGvqS+sbp15rnETIWyuPg8imvxboSrHyOlEBGBUurF5v1nHZpfbk4PAYpk8Q6K20ofScbNf1aXp/lOLHAemA==",
+            "license": "MIT"
         },
         "node_modules/@types/d3-array": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@mantine/notifications": "7.16.2",
         "@mantine/nprogress": "7.16.2",
         "@mantine/spotlight": "7.16.2",
+        "@plotly/dash-component-plugins": "^1.2.0",
         "dayjs": "^1.11.10",
         "embla-carousel-auto-scroll": "^8.4.0",
         "embla-carousel-autoplay": "^8.4.0",

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -79,7 +79,7 @@ const NavLink = ({
         setLinkActive(
           active === true ||
             (active === 'exact' && pathname === href) ||
-            (active === 'partial' && (pathname.startsWith(href + '/') || pathname == href))
+            (active === 'partial' && (pathname.startsWith(href + '/') || pathname === href))
         );
     };
 

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -27,7 +27,7 @@ interface Props
      mimics NavLink behaviour from dash-bootstrap-components
      exact will match the pathname exactly, whereas partial will only be concerned about the startsWith
      */
-    active?: boolean | 'partial' | 'exact';
+    active?: boolean | 'partial' | 'exact' | 'hyperlink';
     /** Key of `theme.colors` of any valid CSS color to control active styles, `theme.primaryColor` by default */
     color?: MantineColor;
     /** href */
@@ -77,16 +77,27 @@ const NavLink = (props: Props) => {
         setLinkActive(
           active === true ||
             (active === 'exact' && pathname === href) ||
-            (active === 'partial' && pathname.startsWith(href))
+            (active === 'partial' && pathname.startsWith(href)) ||
+            (active === 'hyperlink' && pathname.endsWith(href))
         );
     };
 
+    const parsePath = (location) => {
+        if (active === 'hyperlink') {
+          pathnameToActive(location.href)
+        }
+        else {
+          pathnameToActive(location.pathname)
+        }
+    }
+
     useEffect(() => {
-        pathnameToActive(window.location.pathname);
+        parsePath(window.location);
 
         if (typeof active === 'string') {
           History.onChange(() => {
-            pathnameToActive(window.location.pathname);
+              parsePath(window.location);
+            ;
           });
         }
     }, [active]);

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -26,12 +26,11 @@ interface Props
     /** Section displayed on the right side of the label */
     rightSection?: React.ReactNode;
     /**
-     * Determines whether the link should have active styles, `false` by default. Can also set active styles based on the URL match type:
-     * - `exact`: The link is active only if the `pathname` exactly matches `href`.
-     * - `starts-with`: The link is active if the `pathname` begins with `href`, allowing for subpages.
-     * - `ends-with`: The link is active if the full URL (including query parameters and hash) ends with `href`
+     * Controls whether the link is styled as active (default: `false`).
+     * - `exact`: Active if `pathname` matches `href` exactly.
+     * - `partial`: Active if `pathname` starts with `href` (for subpages).
      */
-    active?: boolean | 'starts-with' | 'exact' | 'ends-with';
+    active?: boolean | 'exact' | 'partial';
     /** Key of `theme.colors` of any valid CSS color to control active styles, `theme.primaryColor` by default */
     color?: MantineColor;
     /** href */
@@ -71,7 +70,7 @@ const NavLink = ({
     persistence_type,
     setProps,
     loading_state,
-    active,
+    active = false,
     ...others
 }: Props) => {
     const [linkActive, setLinkActive] = useState(false);
@@ -80,27 +79,16 @@ const NavLink = ({
         setLinkActive(
           active === true ||
             (active === 'exact' && pathname === href) ||
-            (active === 'starts-with' && pathname.startsWith(href)) ||
-            (active === 'ends-with' && pathname.endsWith(href))
+            (active === 'partial' && pathname.startsWith(href))
         );
     };
 
-    const parsePath = (location) => {
-        if (active === 'ends-with') {
-          pathnameToActive(location.href)
-        }
-        else {
-          pathnameToActive(location.pathname)
-        }
-    }
-
     useEffect(() => {
-        parsePath(window.location);
+        pathnameToActive(window.location.pathname);
 
         if (typeof active === 'string') {
           History.onChange(() => {
-              parsePath(window.location);
-            ;
+            pathnameToActive(window.location.pathname);
           });
         }
     }, [active]);

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -25,11 +25,13 @@ interface Props
     leftSection?: React.ReactNode;
     /** Section displayed on the right side of the label */
     rightSection?: React.ReactNode;
-    /** Determines whether the link should have active styles, `false` by default,
-     mimics NavLink behaviour from dash-bootstrap-components
-     exact will match the pathname exactly, whereas partial will only be concerned about the startsWith
+    /**
+     * Determines whether the link should have active styles, `false` by default. Can also set active styles based on the URL match type:
+     * - `exact`: The link is active only if the `pathname` exactly matches `href`.
+     * - `starts-with`: The link is active if the `pathname` begins with `href`, allowing for subpages.
+     * - `ends-with`: The link is active if the full URL (including query parameters and hash) ends with `href`
      */
-    active?: boolean | 'partial' | 'exact' | 'hyperlink';
+    active?: boolean | 'starts-with' | 'exact' | 'ends-with';
     /** Key of `theme.colors` of any valid CSS color to control active styles, `theme.primaryColor` by default */
     color?: MantineColor;
     /** href */
@@ -78,13 +80,13 @@ const NavLink = ({
         setLinkActive(
           active === true ||
             (active === 'exact' && pathname === href) ||
-            (active === 'partial' && pathname.startsWith(href)) ||
-            (active === 'hyperlink' && pathname.endsWith(href))
+            (active === 'starts-with' && pathname.startsWith(href)) ||
+            (active === 'ends-with' && pathname.endsWith(href))
         );
     };
 
     const parsePath = (location) => {
-        if (active === 'hyperlink') {
+        if (active === 'ends-with') {
           pathnameToActive(location.href)
         }
         else {

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -129,6 +129,7 @@ const NavLink = ({
                 disabled={disabled}
                 onChange={onChange}
                 onClick={increment}
+                active={linkActive}
                 {...others}
             >
                 {children}

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -79,7 +79,7 @@ const NavLink = ({
         setLinkActive(
           active === true ||
             (active === 'exact' && pathname === href) ||
-            (active === 'partial' && pathname.startsWith(href))
+            (active === 'partial' && (pathname.startsWith(href + '/') || pathname == href))
         );
     };
 

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -20,7 +20,11 @@ def navlink_app(active):
     ])
     return app
 
-def self_check_navlink(active, dash_duo):
+def self_check_navlink(active, dash_duo, app):
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#link-0")
     els = dash_duo.find_elements('a[data-active]')
     if isinstance(active, bool):
         if active:
@@ -47,38 +51,18 @@ def self_check_navlink(active, dash_duo):
 
 
 def test_001nl_navlink(dash_duo):
-
     app = navlink_app(True)
-    dash_duo.start_server(app)
-
-    # Wait for the app to load
-    dash_duo.wait_for_element("#link-0")
-    self_check_navlink(True, dash_duo)
+    self_check_navlink(True, dash_duo, app)
 
 def test_002nl_navlink(dash_duo):
-
     app = navlink_app(False)
-    dash_duo.start_server(app)
-
-    # Wait for the app to load
-    dash_duo.wait_for_element("#link-0")
-    self_check_navlink(False, dash_duo)
+    self_check_navlink(False, dash_duo, app)
 
 def test_003nl_navlink(dash_duo):
-
     app = navlink_app('exact')
-    dash_duo.start_server(app)
-
-    # Wait for the app to load
-    dash_duo.wait_for_element("#link-0")
-    self_check_navlink('exact', dash_duo)
+    self_check_navlink('exact', dash_duo, app)
 
 def test_004nl_navlink(dash_duo):
-
     app = navlink_app('partial')
-    dash_duo.start_server(app)
-
-    # Wait for the app to load
-    dash_duo.wait_for_element("#link-0")
-    self_check_navlink('partial', dash_duo)
+    self_check_navlink('partial', dash_duo, app)
 

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -1,7 +1,7 @@
 import dash
 from dash import Dash, html, Output, Input, _dash_renderer, ALL, State
 import dash_mantine_components as dmc
-
+import time
 _dash_renderer._set_react_version("18.2.0")
 
 
@@ -11,9 +11,11 @@ def navlink_app(active):
     app.layout = dmc.MantineProvider([
         html.Div(
             [
-                dmc.NavLink(label=f"link-{x}", id=f"link-{x}", href=f"/link-{x}", active=active,
-                            w=300)
-                for x in range(30)
+                dmc.NavLink(label=f"link-{x}", id=f"link-{x}", href=f"/link-{x}", active=active)
+                for x in range(20)
+            ] + [
+                dmc.NavLink(label=f"link-{x}/{x}", id=f"link-{x}-{x}", href=f"/link-{x}/{x}", active=active)
+                for x in range(20)
             ]
         ),
         dash.page_container
@@ -28,26 +30,29 @@ def self_check_navlink(active, dash_duo, app):
     els = dash_duo.find_elements('a[data-active]')
     if isinstance(active, bool):
         if active:
-            assert len(els) == 30
+            assert len(els) == 40
             assert len(dash_duo.find_elements('a:not([data-active])')) == 0
         else:
             assert len(els) == 0
-            assert len(dash_duo.find_elements('a:not([data-active])')) == 30
+            assert len(dash_duo.find_elements('a:not([data-active])')) == 40
         return
     else:
         assert len(els) == 0
-    for t in [1, 5, 10, 12, 13, 20, 22]:
+    for t in [1, 5, 10, 12, 13]:
         dash_duo.find_element(f'#link-{t}').click()
+        els = dash_duo.find_elements('a[data-active]')
+        assert len(els) == 1
+
+    for t in ['1-1', '5-5', '10-10', '12-12', '13-13']:
+
+        dash_duo.find_element(f"#link-{t}").click()
         els = dash_duo.find_elements('a[data-active]')
         if active == 'exact':
             assert len(els) == 1
         else:
-            if len(str(t)) > 1:
-                assert len(els) == 2
-            else:
-                assert len(els) == 1
-            for el in els:
-                assert el.get_attribute('id') in f"link-{t}"
+            assert len(els) == 2
+
+
 
 
 def test_001nl_navlink(dash_duo):

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -1,0 +1,84 @@
+import dash
+from dash import Dash, html, Output, Input, _dash_renderer, ALL, State
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+
+def navlink_app(active):
+    app = Dash(__name__, use_pages=True, pages_folder='')
+
+    app.layout = dmc.MantineProvider([
+        html.Div(
+            [
+                dmc.NavLink(label=f"link-{x}", id=f"link-{x}", href=f"/link-{x}", active=active,
+                            w=300)
+                for x in range(30)
+            ]
+        ),
+        dash.page_container
+    ])
+    return app
+
+def self_check_navlink(active, dash_duo):
+    els = dash_duo.find_elements('a[data-active]')
+    if isinstance(active, bool):
+        if active:
+            assert len(els) == 30
+            assert len(dash_duo.find_elements('a:not([data-active])')) == 0
+        else:
+            assert len(els) == 0
+            assert len(dash_duo.find_elements('a:not([data-active])')) == 30
+        return
+    else:
+        assert len(els) == 0
+    for t in [1, 5, 10, 12, 13, 20, 22]:
+        dash_duo.find_element(f'#link-{t}').click()
+        els = dash_duo.find_elements('a[data-active]')
+        if active == 'exact':
+            assert len(els) == 1
+        else:
+            if len(str(t)) > 1:
+                assert len(els) == 2
+            else:
+                assert len(els) == 1
+            for el in els:
+                assert el.get_attribute('id') in f"link-{t}"
+
+
+def test_001nl_navlink(dash_duo):
+
+    app = navlink_app(True)
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#link-0")
+    self_check_navlink(True, dash_duo)
+
+def test_002nl_navlink(dash_duo):
+
+    app = navlink_app(False)
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#link-0")
+    self_check_navlink(False, dash_duo)
+
+def test_003nl_navlink(dash_duo):
+
+    app = navlink_app('exact')
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#link-0")
+    self_check_navlink('exact', dash_duo)
+
+def test_004nl_navlink(dash_duo):
+
+    app = navlink_app('partial')
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_element("#link-0")
+    self_check_navlink('partial', dash_duo)
+

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -63,6 +63,6 @@ def test_003nl_navlink(dash_duo):
     self_check_navlink('exact', dash_duo, app)
 
 def test_004nl_navlink(dash_duo):
-    app = navlink_app('partial')
-    self_check_navlink('partial', dash_duo, app)
+    app = navlink_app('starts-with')
+    self_check_navlink('starts-with', dash_duo, app)
 

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -63,6 +63,6 @@ def test_003nl_navlink(dash_duo):
     self_check_navlink('exact', dash_duo, app)
 
 def test_004nl_navlink(dash_duo):
-    app = navlink_app('starts-with')
-    self_check_navlink('starts-with', dash_duo, app)
+    app = navlink_app('partial')
+    self_check_navlink('partial', dash_duo, app)
 


### PR DESCRIPTION
adding support for `NavLink` to set active based upon page navigation automatically:

- options for `active` are now `boolean | 'partial' | 'exact'`
- partial will care if the pathname starts with the `href`
- exact will display if the pathname is an exact match
- true / false will disable the matching and set true and false respectively

closes #365 