### PR TITLE
fixed error in alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - `exact`: Marks the link as active only when `pathname` exactly matches `href`.
   - `partial`: Marks the link as active when `pathname` starts with `href`, allowing for subpages.
 
+### Fixed
+- Corrected an error in the `Alert` component when the `duration` prop prop was set when using dash>=3 #516 by @AnnMarieW
 
 # 1.0.0rc1
 

--- a/src/ts/components/core/Alert.tsx
+++ b/src/ts/components/core/Alert.tsx
@@ -35,6 +35,7 @@ interface Props extends BoxProps, StylesApiProps, DashBaseProps {
 /** Alert */
 const Alert = ({ children, setProps, loading_state, duration, hide = false, ...others }: Props) => {
     const ref = useRef(null);
+    const isLoading = getLoadingState(loading_state)
 
     useEffect(() => {
         if (duration) {
@@ -55,7 +56,7 @@ const Alert = ({ children, setProps, loading_state, duration, hide = false, ...o
         <MantineAlert
             {...others}
             onClose={onClose}
-            data-dash-is-loading={getLoadingState(loading_state) || undefined}
+            data-dash-is-loading={isLoading || undefined}
         >
             {children}
         </MantineAlert>

--- a/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
+++ b/src/ts/components/extensions/codehighlight/CodeHighlightTabs.tsx
@@ -46,7 +46,6 @@ const CodeHighlightTabs = (props: Props) => {
     } else {
         renderedCode.push(renderDashComponents(code, ["icon"]));
     }
-    console.log(renderedCode)
 
     return (
         <MantineCodeHighlightTabs

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,0 +1,20 @@
+import time
+from dash import Dash, html, _dash_renderer
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+
+def test_001al_alert(dash_duo):
+    app = Dash(__name__)
+
+    avatar = dmc.Alert("Alert text", id="alert", duration=200)
+
+    app.layout = dmc.MantineProvider(html.Div([avatar]))
+
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_text_to_equal("#alert", "Alert text")
+    time.sleep(.3)
+    assert dash_duo.get_logs() == []


### PR DESCRIPTION
Closes #517 

The `Alert` component with `duration` set generated the following error when using dash 3:

> Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

The return for this component is conditional - checking the loading state at the top level rather than inside the conditional return eliminates the error.
```js
    return hide ? null : (
        <MantineAlert
           data-dash-is-loading={getLoadingState(loading_state) || undefined}
```




```python
import dash_mantine_components as dmc
from dash import Dash, Input, Output, State, callback, html

app = Dash(external_stylesheets=dmc.styles.ALL)

component = html.Div(
    [
        dmc.Alert(
            "This alert will dismiss itself after 3 seconds! ",
            title="Auto Dismissing Alert!",
            id="alert-auto",
            color="violet",
            duration=3000,
        ),
        dmc.Button("Show alert", id="alert-auto-button", mt=20),
    ]
)

app.layout = dmc.MantineProvider(component)


@callback(
    Output("alert-auto", "hide"),
    Input("alert-auto-button", "n_clicks"),
    prevent_initial_call=True,
)
def alert_auto(n_clicks):
    return False

if __name__ == "__main__":
    app.run(debug=True)

```

