### PR TITLE
Added ability to generate list of 10 colors in the theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@mantine/carousel": "7.17.0",
                 "@mantine/charts": "7.17.0",
                 "@mantine/code-highlight": "7.17.0",
+                "@mantine/colors-generator": "7.17.0",
                 "@mantine/core": "7.17.0",
                 "@mantine/dates": "7.17.0",
                 "@mantine/hooks": "7.17.0",
@@ -515,6 +516,15 @@
                 "@mantine/hooks": "7.17.0",
                 "react": "^18.x || ^19.x",
                 "react-dom": "^18.x || ^19.x"
+            }
+        },
+        "node_modules/@mantine/colors-generator": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@mantine/colors-generator/-/colors-generator-7.17.0.tgz",
+            "integrity": "sha512-3kpjaOhjxCYlrhSCSkQPPGZnntqFF5GdhghjkVujCFEFj1JUnn+1TY/jQI+VLz0kioJdFarPiaGHZHlAM7ps1A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "chroma-js": ">=2.4.2"
             }
         },
         "node_modules/@mantine/core": {
@@ -1223,6 +1233,13 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/chroma-js": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.1.2.tgz",
+            "integrity": "sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==",
+            "license": "(BSD-3-Clause AND Apache-2.0)",
+            "peer": true
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@mantine/notifications": "7.17.0",
         "@mantine/nprogress": "7.17.0",
         "@mantine/spotlight": "7.17.0",
+        "@mantine/colors-generator":  "7.17.0",
         "@plotly/dash-component-plugins": "^1.2.0",
         "dayjs": "^1.11.10",
         "embla-carousel-auto-scroll": "^8.4.0",

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -2,6 +2,7 @@ import {
     MantineProvider as MantineMantineProvider,
     MantineProviderProps,
 } from "@mantine/core";
+import { generateColors } from "@mantine/colors-generator";
 import React from "react";
 
 import "@mantine/core/styles.css";
@@ -9,15 +10,29 @@ import "@mantine/core/styles.css";
 interface Props extends MantineProviderProps {
     /** Unique ID to identify this component in Dash callbacks. */
     id?: string;
+    /** Dictionary of colors, where each key is a color name and the value is a base color string.
+     * Each base color is passed to the Mantine  `generateColors` function, which returns an array of 10 color shades.
+     */
+    colorsGenerator?: Record<string, string>;
 }
 
 /* MantineProvider */
-const MantineProvider = (props: Props) => {
-    const { children, ...others } = props;
-
-    return (
-        <MantineMantineProvider {...others}>{children}</MantineMantineProvider>
+const MantineProvider = ({ children, theme, colorsGenerator = {}, ...others }: Props) => {
+    // Transform each color in colorsGenerator using generateColors
+    const additionalColors = Object.fromEntries(
+        Object.entries(colorsGenerator).map(([key, value]) => [
+            key,
+            typeof value === "string" ? generateColors(value) : [],
+        ])
     );
+
+    // Merge new colors with existing ones, preserving original colors
+    const newTheme = {
+        ...theme,
+        colors: { ...theme?.colors, ...additionalColors },
+    };
+
+    return <MantineMantineProvider theme={newTheme} {...others}>{children}</MantineMantineProvider>;
 };
 
 export default MantineProvider;


### PR DESCRIPTION
closes #488 

Adds a `colorsGenerator` prop to the `MantineProvider`

 Dictionary of colors, where each key is a color name and the value is a base color string.  Each base color is passed to the Mantine `generateColors` function, which returns an array of 10 color shades.
     
Example:
      `colorsGenerator = { "light-blue": "#375EAC" }`
      
Will be transformed into:
      `{ "light-blue": ["#eff5fc", "#d6e5fa", ..., "#162d50"] }`

This is merged with the `theme.color` object


The `generateColors` function was added to Mantine in V7.0

> New [@mantine/colors-generator](https://mantine.dev/theming/colors#colors-generation) package is now available to generate
color palettes based on single color value. It is also available as [online tool](https://mantine.dev/colors-generator/).
Note that it is usually better to generate colors in advance to avoid contrast issues.

Question:
- given that it's recommended to use the on-line tool, is it worthwhile adding?  It does increase the bundle size some (about 60 KiB)

----------

Here's a sample app:
```

import dash_mantine_components as dmc
from dash import Dash, _dash_renderer, Input, Output, State
_dash_renderer._set_react_version("18.2.0")

app = Dash(external_stylesheets=dmc.styles.ALL)

app.layout = dmc.MantineProvider(
    dmc.Alert("hello dmc"),
    colorsGenerator={'pale-blue': '#375EAC', "another-red": "#f0185c"},
    theme={"primaryColor": "another-red"}
)

if __name__ == "__main__":
    app.run(debug=True)




```
     
  