### PR TITLE
Updates the use of `renderDashComponents` to use `ExternalWrapper` when Dash 3 and falls back on `dash-extensions` for Dash 2

### DIFF
--- a/src/ts/components/core/SegmentedControl.tsx
+++ b/src/ts/components/core/SegmentedControl.tsx
@@ -5,12 +5,12 @@ import {
     MantineSize,
     SegmentedControlItem,
 } from "@mantine/core";
-import { renderDashComponent } from "dash-extensions-js";
+
 import { BoxProps } from "props/box";
 import { DashBaseProps, PersistenceProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import React from "react";
-import { setPersistence, getLoadingState } from "../../utils/dash3";
+import { setPersistence, getLoadingState, renderDashComponent } from "../../utils/dash3";
 
 interface Props
     extends BoxProps,

--- a/src/ts/components/core/stepper/Stepper.tsx
+++ b/src/ts/components/core/stepper/Stepper.tsx
@@ -6,13 +6,12 @@ import {
     Stepper as MantineStepper,
 } from "@mantine/core";
 import { useDidUpdate } from "@mantine/hooks";
-import { renderDashComponents } from "dash-extensions-js";
 import { BoxProps } from "props/box";
 import { DashBaseProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import { omit } from "ramda";
 import React, { useState } from "react";
-import { getChildLayout, getLoadingState } from "../../../utils/dash3";
+import { getChildLayout, getLoadingState, renderDashComponents } from "../../../utils/dash3";
 
 interface Props extends BoxProps, DashBaseProps, StylesApiProps {
     /** Index of the active step */
@@ -81,7 +80,7 @@ const Stepper = ({ setProps, loading_state, active, children, ...others }: Props
                             "icon",
                             "progressIcon",
                             "completedIcon",
-                        ]
+                        ], childProps.componentPath
                     );
 
                     return (

--- a/src/ts/components/core/timeline/Timeline.tsx
+++ b/src/ts/components/core/timeline/Timeline.tsx
@@ -3,13 +3,13 @@ import {
     MantineRadius,
     Timeline as MantineTimeline,
 } from "@mantine/core";
-import { renderDashComponents } from "dash-extensions-js";
+
 import { BoxProps } from "props/box";
 import { DashBaseProps } from "props/dash";
 import { StylesApiProps } from "props/styles";
 import { omit } from "ramda";
 import React from "react";
-import { getLoadingState, getChildProps } from "../../../utils/dash3";
+import { getLoadingState, getChildProps, renderDashComponents } from "../../../utils/dash3";
 
 interface Props extends BoxProps, StylesApiProps, DashBaseProps {
     /** `Timeline.Item` components */

--- a/src/ts/components/extensions/codehighlight/fragments/CodeHighlightTabs.tsx
+++ b/src/ts/components/extensions/codehighlight/fragments/CodeHighlightTabs.tsx
@@ -2,9 +2,9 @@ import {
     CodeHighlightTabs as MantineCodeHighlightTabs,
 } from "@mantine/code-highlight";
 import "@mantine/code-highlight/styles.css";
-import { renderDashComponents } from "dash-extensions-js";
+
 import React from "react";
-import { getLoadingState } from "../../../../utils/dash3";
+import { getLoadingState, renderDashComponents } from "../../../../utils/dash3";
 import { Props }  from "../CodeHighlightTabs"
 
 

--- a/src/ts/utils/dash3.ts
+++ b/src/ts/utils/dash3.ts
@@ -22,7 +22,7 @@ export const renderDashComponent = (component: any, index?: number | null, baseP
         const {renderDashComponent: ol_renderDashComponent} = dash_extensions;
         return ol_renderDashComponent(component, index)
     }
-    console.log('rendering')
+
     // Nothing to render.
     if (isNil(component) || isEmpty(component)) {
         return null;


### PR DESCRIPTION
The alteration will allow complex components to be mapped to allow callbacks from components.

eg:

```
import dash
from dash import Dash, _dash_renderer, clientside_callback, html, Output, Input, State, ctx, callback
import dash_mantine_components as dmc
_dash_renderer._set_react_version("18.2.0")

app = Dash()

min_step = 0
max_step = 3
active = 1

layout = html.Div(
    [
        dmc.Stepper(
            id="stepper-basic-usage",
            active=active,
            children=[
                dmc.StepperStep(
                    label="First step",
                    description=["Create an account",
                                 "test 2",
                                 html.H1(dmc.Button(id='rawr', children='test'), id='123', style={'color': 'red'})],
                    children=[
                        dmc.Text("Step 1 content: Create an account", ta="center"),
                    ],
                ),
                dmc.StepperStep(
                    label="Second step",
                    description="Verify email",
                    children=dmc.Text("Step 2 content: Verify email", ta="center"),
                ),
                dmc.StepperStep(
                    label="Final step",
                    description="Get full access",
                    children=dmc.Text("Step 3 content: Get full access", ta="center"),
                ),
                dmc.StepperCompleted(
                    children=dmc.Text(
                        "Completed, click back button to get to previous step",
                        ta="center",
                    )
                ),
            ],
        ),
        dmc.Group(
            justify="center",
            mt="xl",
            children=[
                dmc.Button("Back", id="back-basic-usage", variant="default"),
                dmc.Button("Next step", id="next-basic-usage"),
            ],
        ),
    ]
)



clientside_callback("""(n)=> {
    alert(`clicked ${n} times`)
}""",
Input('rawr', 'n_clicks'),
prevent_initial_call=True,
suppress_callback_exceptions=True)

clientside_callback(
    """(a) => {
        return a != 0
    }""",
    Output('rawr', 'disabled'),
    Input('stepper-basic-usage', 'active')
)

@callback(
    Output("stepper-basic-usage", "active"),
    Input("back-basic-usage", "n_clicks"),
    Input("next-basic-usage", "n_clicks"),
    State("stepper-basic-usage", "active"),
    prevent_initial_call=True,
)
def update(back, next_, current):
    button_id = ctx.triggered_id
    step = current if current is not None else active
    if button_id == "back-basic-usage":
        step = step - 1 if step > min_step else step
    else:
        step = step + 1 if step < max_step else step
    return step


app.layout = dmc.MantineProvider(
    layout
)

print(dash.__version__)

if __name__ == "__main__":
    app.run(debug=True)
```

In Dash 2, clicking on the button "rawr" doesnt trigger the callback, however, in Dash 3 you can see that this triggers.