### PR TITLE
Multiselect filter integration

### DIFF
--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -7,8 +7,8 @@ import { __ClearButtonProps } from "props/button";
 import { __BaseInputProps } from "props/input";
 import { ScrollAreaProps } from "props/scrollarea";
 import { StylesApiProps } from "props/styles";
-import React, { useState } from "react";
-import { filterSelected } from "../../../utils/combobox";
+import React, { useState, useEffect } from "react";
+import { filterSelected, stringToFunction } from "../../../utils/combobox";
 import { setPersistence, getLoadingState } from "../../../utils/dash3";
 
 interface Props
@@ -59,12 +59,23 @@ const MultiSelect = ({
         n_blur = 0,
         data = [],
         value = [],
+        comboboxProps = {},
         ...others
     }: Props) => {
 
     const [selected, setSelected] = useState(value);
     const [options, setOptions] = useState(data);
     const { ref, focused } = useFocusWithin();
+    const [filterFunction, setFilterFunction] = useState(null);
+
+    // Process filter function if provided in comboboxProps
+    useEffect(() => {
+        if (comboboxProps?.filter) {
+            setFilterFunction(() => stringToFunction(comboboxProps.filter));
+        } else {
+            setFilterFunction(null);
+        }
+    }, [comboboxProps?.filter]);
 
     const debounceValue = typeof debounce === "number" ? debounce : 0;
     const [debounced] = useDebouncedValue(selected, debounceValue);
@@ -115,6 +126,9 @@ const MultiSelect = ({
         setProps({ data: options });
     }, [options]);
 
+    // Prepare combobox props without filter since we handle it separately
+    const { filter, ...restComboboxProps } = comboboxProps;
+
     return (
         <div ref={ref}>
             <MantineMultiSelect
@@ -125,13 +139,14 @@ const MultiSelect = ({
                 onChange={setSelected}
                 value={selected}
                 onSearchChange={handleSearchChange}
+                filter={filterFunction}
+                {...restComboboxProps}
                 {...others}
             />
         </div>
     );
 };
 
-
-setPersistence(MultiSelect)
+setPersistence(MultiSelect);
 
 export default MultiSelect;

--- a/src/ts/props/combobox.ts
+++ b/src/ts/props/combobox.ts
@@ -13,6 +13,8 @@ interface ComboboxProps extends __PopoverProps, StylesApiProps {
     resetSelectionOnOptionHover?: boolean;
     /** Determines whether Combobox value can be changed */
     readOnly?: boolean;
+    /** Custom filter function as a string (JavaScript code) */
+    filter?: string;
 }
 
 export interface ComboboxLikeProps {

--- a/src/ts/utils/combobox.ts
+++ b/src/ts/utils/combobox.ts
@@ -34,17 +34,21 @@ export const filterSelected = (options, values) => {
 // Generic function to convert a string filter to a function
 export const stringToFunction = (code: string) => {
     try {
-        // Using Function constructor to create a function from string
-        return new Function('search', 'item', `
-            try {
-                ${code}
-            } catch (error) {
-                console.error('Error executing filter function:', error);
-                return false;
-            }
-        `);
+      return new Function('params', `
+        try {
+          const { options, search } = params;
+          if (!search || !options) return options;
+          
+          return options.filter(item => {
+            ${code}
+          });
+        } catch (error) {
+          console.error('Error executing filter function:', error);
+          return params.options;
+        }
+      `);
     } catch (error) {
-        console.error('Error creating filter function:', error);
-        return (search: string, item: any) => true; // Default to showing all items
+      console.error('Error creating filter function:', error);
+      return ({ options }) => options;
     }
 };

--- a/src/ts/utils/combobox.ts
+++ b/src/ts/utils/combobox.ts
@@ -30,3 +30,21 @@ export const filterSelected = (options, values) => {
         return optionValues.includes(values) ? values : null;
     }
 };
+
+// Generic function to convert a string filter to a function
+export const stringToFunction = (code: string) => {
+    try {
+        // Using Function constructor to create a function from string
+        return new Function('search', 'item', `
+            try {
+                ${code}
+            } catch (error) {
+                console.error('Error executing filter function:', error);
+                return false;
+            }
+        `);
+    } catch (error) {
+        console.error('Error creating filter function:', error);
+        return (search: string, item: any) => true; // Default to showing all items
+    }
+};


### PR DESCRIPTION
## Description
This is an attempt to solve issue #534 with integrating filter and allowing the functionality to be the same as mantine upstream while also, making sure this complies with the dash mantine roadmap.

I have not tested these completely,  heres how the user would be able to run this:

## Changes

1. Added stringToFunction utility to convert string filter code to executable functions
2. Added filter prop to ComboboxProps interface
3. Updated MultiSelect to support custom filter functions via comboboxProps.filter
4. Filters are executed within a try/catch block for safety

## Solution usage
Heres how users will use this functionality:
```
import dash
from dash import html, _dash_renderer
import dash_mantine_components as dmc


_dash_renderer._set_react_version("18.2.0")

app = dash.Dash(__name__)

wildcard_filter = """
const itemValue = typeof item === 'string' ? item : item.value || item.label || '';
const itemLabel = (typeof item === 'object' && item.label) ? item.label : itemValue.toString();

if (search.includes('*')) {
    const pattern = search.replace(/\\*/g, '.*');
    const regex = new RegExp(pattern, 'i');
    return regex.test(itemLabel);
}

return itemLabel.toLowerCase().includes(search.toLowerCase());
"""

app.layout = dmc.MantineProvider([
    dmc.MultiSelect(
        id="test-select",
        data=["Option 10", "Option 100", "Option 1000"],
        label="Test Wildcard Filter",
        placeholder="Try '10*' or '*Thing'", 
        searchable=True,
        comboboxProps={"filter": wildcard_filter}
    ),
    html.Div(id="output")
])

if __name__ == '__main__':
    app.run_server(debug=True)
```

## Potential Test Cases

- [x] Base functionality works without filter
- [x] Custom filter function can be passed and executed
- [x] Wildcard filter works with patterns (10*, thing, az)
- [x] Filter handles edge cases (empty search, malformed patterns) 

I would love your thoughts on this @AnnMarieW if this is a more adequate solution!

edit: my current use case seems to be i want all the values found after the wildcard/filter and then the user should have a button to select them all or some way to grab all those relevant values. will need to see what is the equivalent to that on mantine

edit 2 : it seems a functionality like that does not exist in mantine, it was discussed a bit in the github discussions https://github.com/orgs/mantinedev/discussions/3635 on mantinedev. Any thoughts on if we can add the select all feature here to multiselect? 