### PR TITLE
Fix unselect not working in RadioGroup

### DIFF
--- a/src/ts/components/core/radio/RadioGroup.tsx
+++ b/src/ts/components/core/radio/RadioGroup.tsx
@@ -36,8 +36,10 @@ const RadioGroup = (props: Props) => {
         ...others
     } = props;
 
-    const onChange = (value: string) => {
-        setProps({ value });
+    const onChange = (val: string) => {
+        if (val !== value) {
+            setProps({ value: val });
+        }
     };
 
     const handleRadioClick = (val?: string) => {


### PR DESCRIPTION
Fix test failure. Seemed like a race condition in RadioGroup. By changing the Dash update invocation to only happen on value changes, the test passes every time. Behaviour validated manually also.