### PR TITLE
add inputProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# Unreleased
+
+### Added
+
+- Added `inputProps` to JsonInput, NumberInput, PasswordInput, TextInput, and TextArea components to allow passing props directly to the underlying input element. #568 by @AnnMarieW
+
+
 # 1.1.2rc1
 
 ### Fixed

--- a/src/ts/components/core/input/JsonInput.tsx
+++ b/src/ts/components/core/input/JsonInput.tsx
@@ -64,13 +64,13 @@ const JsonInput = ({
 
     return (
         <MantineJsonInput
+            {...inputProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onChange={setVal}
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
-            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/JsonInput.tsx
+++ b/src/ts/components/core/input/JsonInput.tsx
@@ -28,6 +28,7 @@ const JsonInput = ({
     n_blur = 0,
     debounce = false,
     autoComplete = "off",
+    inputProps,
     ...others
 }: Props) => {
 
@@ -69,6 +70,7 @@ const JsonInput = ({
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
+            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/NumberInput.tsx
+++ b/src/ts/components/core/input/NumberInput.tsx
@@ -114,13 +114,13 @@ const NumberInput = ({
 
     return (
         <MantineNumberInput
+            {...inputProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onChange={setVal}
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
-            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/NumberInput.tsx
+++ b/src/ts/components/core/input/NumberInput.tsx
@@ -77,6 +77,7 @@ const NumberInput = ({
     n_blur = 0,
     debounce = false,
     autoComplete = "off",
+    inputProps,
     ...others
 }: Props) => {
 
@@ -119,6 +120,7 @@ const NumberInput = ({
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
+            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/PasswordInput.tsx
+++ b/src/ts/components/core/input/PasswordInput.tsx
@@ -36,6 +36,7 @@ const PasswordInput = ({
     n_blur = 0,
     debounce = false,
     autoComplete = "off",
+    inputProps,
     ...others
 }: Props) => {
 
@@ -77,6 +78,7 @@ const PasswordInput = ({
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
+            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/PasswordInput.tsx
+++ b/src/ts/components/core/input/PasswordInput.tsx
@@ -72,13 +72,13 @@ const PasswordInput = ({
 
     return (
         <MantinePasswordInput
+            {...inputProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
-            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/PinInput.tsx
+++ b/src/ts/components/core/input/PinInput.tsx
@@ -68,12 +68,13 @@ interface Props
 
 /** PinInput */
 const PinInput = (props: Props) => {
-    const { setProps, loading_state, value, ...others } = props;
+    const { setProps, loading_state, value, inputProps, ...others } = props;
 
     return (
         <MantinePinInput
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onComplete={(value) => setProps({ value })}
+            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/PinInput.tsx
+++ b/src/ts/components/core/input/PinInput.tsx
@@ -68,13 +68,12 @@ interface Props
 
 /** PinInput */
 const PinInput = (props: Props) => {
-    const { setProps, loading_state, value, inputProps, ...others } = props;
+    const { setProps, loading_state, value, ...others } = props;
 
     return (
         <MantinePinInput
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onComplete={(value) => setProps({ value })}
-            {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/TextInput.tsx
+++ b/src/ts/components/core/input/TextInput.tsx
@@ -34,6 +34,7 @@ const TextInput = ({
     n_blur = 0,
     debounce = false,
     autoComplete = "off",
+    inputProps,
     ...others
 }: Props) => {
 
@@ -76,6 +77,7 @@ const TextInput = ({
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
+             {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/TextInput.tsx
+++ b/src/ts/components/core/input/TextInput.tsx
@@ -71,13 +71,13 @@ const TextInput = ({
 
     return (
         <MantineTextInput
+            {...inputProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onChange={(ev) => setVal(ev.currentTarget.value)}
             value={val}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             autoComplete={autoComplete}
-             {...inputProps}
             {...others}
         />
     );

--- a/src/ts/components/core/input/Textarea.tsx
+++ b/src/ts/components/core/input/Textarea.tsx
@@ -26,6 +26,7 @@ const Textarea = ({
     n_blur = 0,
     debounce = false,
     autoComplete = "off",
+    inputProps,
     ...others
 }: Props) => {
 
@@ -63,6 +64,7 @@ const Textarea = ({
         <MantineTextarea
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             autoComplete={autoComplete}
+            {...inputProps}
             {...others}
             value={val}
             onChange={(ev) => setVal(ev.currentTarget.value)}

--- a/src/ts/components/core/input/Textarea.tsx
+++ b/src/ts/components/core/input/Textarea.tsx
@@ -62,9 +62,9 @@ const Textarea = ({
 
     return (
         <MantineTextarea
+            {...inputProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             autoComplete={autoComplete}
-            {...inputProps}
             {...others}
             value={val}
             onChange={(ev) => setVal(ev.currentTarget.value)}

--- a/src/ts/props/input.ts
+++ b/src/ts/props/input.ts
@@ -21,6 +21,8 @@ export interface __InputWrapperProps {
     errorProps?: Record<string, any>;
     /** Controls order of the elements, `['label', 'description', 'input', 'error']` by default */
     inputWrapperOrder?: ("label" | "input" | "description" | "error")[];
+     /** Props passed down to the `Input` component */
+    inputProps?: Record<string, any>;
 }
 
 export interface InputWrapperProps

--- a/src/ts/props/input.ts
+++ b/src/ts/props/input.ts
@@ -21,8 +21,6 @@ export interface __InputWrapperProps {
     errorProps?: Record<string, any>;
     /** Controls order of the elements, `['label', 'description', 'input', 'error']` by default */
     inputWrapperOrder?: ("label" | "input" | "description" | "error")[];
-     /** Props passed down to the `Input` component */
-    inputProps?: Record<string, any>;
 }
 
 export interface InputWrapperProps
@@ -70,6 +68,8 @@ export interface __InputProps {
     placeholder?: string;
     /** Name prop */
     name?: string;
+    /** Props passed down to the `Input` component */
+    inputProps?: Record<string, any>;
 }
 
 export interface InputProps extends BoxProps, __InputProps, StylesApiProps {

--- a/tests/input/test_textarea.py
+++ b/tests/input/test_textarea.py
@@ -11,6 +11,7 @@ debounce = dmc.Stack(
     [
         dmc.Textarea(
             id="debounce-true",
+            inputProps={"maxlength": 10},
             debounce=True,
         ),
         dmc.Box(id="out-true"),
@@ -75,5 +76,7 @@ def test_001te_textarea(dash_duo):
 
     # but do expect that it is eventually called
     dash_duo.wait_for_text_to_equal("#out-2000", "x")
+
+    assert dash_duo.find_element('#debounce-true').get_attribute('maxlength') == '10'
 
     assert dash_duo.get_logs() == []


### PR DESCRIPTION
closes #547 

This PR addes `inputProps` to make it possible to pass any valid attribute to the `input` element.

For example as requested in issue 547, you can include maxlength like this:

```python
dmc.TextArea(inputProps={"maxLength": 3})

```