### PR TITLE
allow functions as props

### DIFF
--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -11,6 +11,7 @@ import { StylesApiProps } from "props/styles";
 import { TransitionProps } from "props/transition";
 import React, { useState } from "react";
 import { setPersistence, getLoadingState } from "../../../utils/dash3";
+import { resolveProp } from "../../../utils/prop-functions"
 
 interface Props
     extends BoxProps,
@@ -70,6 +71,7 @@ const Slider = ({
     loading_state,
     updatemode = "mouseup",
     value,
+    label,
     persistence,
     persisted_props,
     persistence_type,
@@ -94,6 +96,7 @@ const Slider = ({
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             {...others}
             value={val}
+            label={resolveProp(label)}
             onChange={setVal}
             onChangeEnd={(value) => {
                 if (updatemode === "mouseup") {

--- a/src/ts/utils/prop-functions.ts
+++ b/src/ts/utils/prop-functions.ts
@@ -1,0 +1,78 @@
+/**
+ * Utility to allow passing a function as a prop from a dash app.
+ * For example label={'function': 'myLabel'}
+ * where 'myLabel' is a function defined in .js file in /assets
+ *
+ */
+
+export const context = {
+//             d3,
+//             dash_clientside,
+//             ...customFunctions,
+           ...(window as any).dashMantineComponentsFunctions
+        };
+
+
+function isPlainObject(o) {
+   return (o === null || Array.isArray(o) || typeof o == 'function' || o.constructor === Date ) ?
+           false
+          :(typeof o == 'object');
+}
+
+function isFunction(functionToCheck) {
+   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}
+
+
+export function resolveProp(prop, context = {}) {
+    // If it's not an object, just return.
+    if (!isPlainObject(prop)){
+        return prop
+    }
+    // Check if the prop should be resolved a variable.
+    if (prop.function){
+        return resolveVariable(prop, context)
+    }
+    // Check if the prop should be resolved as an arrow function.
+    if (prop.arrow){
+        return (...args) => prop.arrow
+    }
+    // If none of the special properties are present, do nothing.
+    return prop
+}
+
+function resolveVariable(prop, context){
+    const variable = getDescendantProp(window, prop.function)
+
+    // If it's not there, raise an error.
+    if(variable === undefined){
+        throw new Error("No match for [" + prop.function + "] in the global window object.")
+    }
+    // If it's a function, add context.
+    if(isFunction(variable) && context){
+        return (...args) => variable(...args, context)
+    }
+    // Otherwise, use the variable as-is.
+    return variable
+}
+
+function getDescendantProp(obj, desc, defaultPath = "dashMantineComponentsFunctions") {
+    // Use the default path if the provided desc does not contain a dot
+    const path = desc.includes(".") ? desc : `${defaultPath}.${desc}`;
+
+    // allows for nested paths  for example "myNamespace.mySubNamespace.myFunction"
+    const arr = path.split(".");
+    while (arr.length && (obj = obj[arr.shift()]));
+    return obj;
+}
+
+function resolveProps(props, functionalProps, context){
+    let nProps = Object.assign({}, props);
+    for(let prop of functionalProps) {
+        if (nProps[prop]) {
+            nProps[prop] = resolveProp(nProps[prop], context);
+        }
+    }
+    return nProps
+}
+


### PR DESCRIPTION
closes #356 

This is the start of allowing function to be passed from a dash app.

In this example the `Slider`  `label` prop can be a function:
> label:  ReactNode | ((value: number) => ReactNode)

It's possible to pass a function that is defined in a `.js` file in `assets` like this:
 ` label={"function": "myLabel"}`



```python

import dash_mantine_components as dmc
from dash import Dash

app = Dash()

app.layout = dmc.MantineProvider(
    dmc.Slider(value=25, p=100, label={"function": "myLabel"})
)

if __name__ == "__main__":
    app.run(debug=True)

```


.js file in /assets:
```js
var dmcfuncs = window.dashMantineComponentsFunctions = window.dashMantineComponentsFunctions || {};

dmcfuncs.myLabel = function(value) {
            return `${value} °C`
        }

```

![image](https://github.com/user-attachments/assets/acd86f9d-1a50-4e62-a1b9-1bd572cb27f6)


