### PR TITLE
Add ModalStack and DrawerStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   - Support functions as props in `renderOption` and `filter` props
   - Added `clearButtonProps` and `clearable` props
 
+- Added  Modal Stack and Drawer Stack components  #606 by @AnnMarieW
+  - Introduced `ModalStack` / `ManagedModal` and `DrawerStack` / `ManagedDrawer` for managing stacked modals and drawers.
+  - `ModalStack` and `DrawerStack` accept the Dash props: `open`, `close`, `toggle`, and `closeAll` to control visibility, and a read-only `state` prop to track which children are open.
+ 
+
 # 2.0.0
 
 ### Changed

--- a/src/ts/components/core/drawer/Drawer.tsx
+++ b/src/ts/components/core/drawer/Drawer.tsx
@@ -1,0 +1,62 @@
+import { Drawer as MantineDrawer, MantineRadius } from '@mantine/core';
+import { DashBaseProps } from 'props/dash';
+import { ModalBaseOverlayProps, ModalBaseProps } from 'props/modal';
+import { StylesApiProps } from 'props/styles';
+import React, { useEffect, useState } from 'react';
+import { getLoadingState } from '../../../utils/dash3';
+
+type DrawerPosition = 'bottom' | 'left' | 'right' | 'top';
+
+interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
+    /** Side of the screen on which drawer will be opened, `'left'` by default */
+    position?: DrawerPosition;
+    /** Key of `theme.radius` or any valid CSS value to set `border-radius`, numbers are converted to rem, `0` by default */
+    radius?: MantineRadius;
+    /** Drawer container offset from the viewport end, `0` by default */
+    offset?: number | string;
+    /** Drawer title */
+    title?: React.ReactNode;
+    /** Determines whether the overlay should be rendered, `true` by default */
+    withOverlay?: boolean;
+    /** Props passed down to the `Overlay` component, can be used to configure opacity, `background-color`, styles and other properties */
+    overlayProps?: ModalBaseOverlayProps;
+    /** Drawer content */
+    children?: React.ReactNode;
+    /** Determines whether the close button should be rendered, `true` by default */
+    withCloseButton?: boolean;
+    /** Props passed down to the close button */
+    closeButtonProps?: object;
+}
+
+/** Drawer */
+const Drawer = ({
+    setProps,
+    loading_state,
+    opened = false,
+    children,
+    ...others
+}: Props) => {
+    const [open, setOpen] = useState(opened);
+
+    useEffect(() => {
+        setOpen(opened);
+    }, [opened]);
+
+    const onClose = () => {
+        setOpen(false);
+        setProps({ opened: false });
+    };
+
+    return (
+        <MantineDrawer
+            data-dash-is-loading={getLoadingState(loading_state) || undefined}
+            opened={open}
+            onClose={onClose}
+            {...others}
+        >
+            {children}
+        </MantineDrawer>
+    );
+};
+
+export default Drawer;

--- a/src/ts/components/core/drawer/DrawerStack.tsx
+++ b/src/ts/components/core/drawer/DrawerStack.tsx
@@ -1,11 +1,12 @@
+import React from 'react';
 import { createStackComponent } from '../../../utils/stack-factory';
 import { Drawer, useDrawersStack } from '@mantine/core';
 import { DashBaseProps } from 'props/dash';
 
-interface Props extends DashBaseProps {
+interface DrawerStackProps extends DashBaseProps {
     /** ManagedDrawer content */
     children?: React.ReactElement[];
-    /** Current opened state of each drawer.  Read only */
+    /** Current opened state of each drawer. Read only */
     state?: Record<string, boolean>;
     /** Opens one or more drawers by ID. Accepts a single ID (string or dict) or a list of IDs. */
     open?: string | Record<string, any> | (string | Record<string, any>)[];
@@ -17,13 +18,18 @@ interface Props extends DashBaseProps {
     closeAll?: boolean;
 }
 
-/** Use DrawerStack component to render multiple drawers at the same time.  */
-const DrawerStack = createStackComponent({
+
+const DrawerStackComponent = createStackComponent({
     name: 'DrawerStack',
     useStackHook: useDrawersStack,
     OuterStack: Drawer.Stack,
     InnerComponent: Drawer,
     expectedType: 'ManagedDrawer',
 });
+
+/** Use DrawerStack to render multiple drawers at the same time */
+const DrawerStack = (props: DrawerStackProps) => {
+    return React.createElement(DrawerStackComponent, props);
+};
 
 export default DrawerStack;

--- a/src/ts/components/core/drawer/DrawerStack.tsx
+++ b/src/ts/components/core/drawer/DrawerStack.tsx
@@ -1,4 +1,4 @@
-import { Modal, useModalsStack } from '@mantine/core';
+import { Drawer, useDrawersStack } from '@mantine/core';
 import { useDidUpdate } from '@mantine/hooks';
 import React from 'react';
 import { DashBaseProps } from 'props/dash';
@@ -11,20 +11,20 @@ import {
 interface Props extends DashBaseProps {
     /** ManagedModel content */
     children?: React.ReactElement[];
-    /** Current opened state of each modal.  Read only */
+    /** Current opened state of each drawer.  Read only */
     state?: Record<string, boolean>;
-    /** Opens one or more modals by ID. Accepts a single ID (string or dict) or a list of IDs. */
+    /** Opens one or more drawers by ID. Accepts a single ID (string or dict) or a list of IDs. */
     open?: string | Record<string, any> | (string | Record<string, any>)[];
-    /** Closes one or more modals by ID. Accepts a single ID (string or dict) or a list of IDs. */
+    /** Closes one or more drawers by ID. Accepts a single ID (string or dict) or a list of IDs. */
     close?: string | Record<string, any> | (string | Record<string, any>)[];
-    /** Toggles one or more modals by ID. Accepts a single ID (string or dict) or a list of IDs. */
+    /** Toggles one or more drawers by ID. Accepts a single ID (string or dict) or a list of IDs. */
     toggle?: string | Record<string, any> | (string | Record<string, any>)[];
-    /** Closes all modals in the ModalStack */
+    /** Closes all drawers in the DrawerStack */
     closeAll?: boolean;
 }
 
-/** Use ModalStack component to render multiple modals at the same time.  */
-const ModalStack = ({
+/** Use DrawerStack component to render multiple drawers at the same time.  */
+const DrawerStack = ({
     children,
     setProps,
     loading_state,
@@ -38,15 +38,15 @@ const ModalStack = ({
     const childrenArray = React.Children.toArray(children);
 
     // get ids of ManagedModels
-    const modalIds = childrenArray
+    const drawerIds = childrenArray
         .map((child) => {
             const { type, props } = getChildLayout(child);
-            return type === 'ManagedModal' ? stringifyId(props.id) : null;
+            return type === 'ManagedDrawer' ? stringifyId(props.id) : null;
         })
         .filter(Boolean) as string[];
 
-    // Initialize useModalsStack
-    const stack = useModalsStack(modalIds);
+    // Initialize useDrawersStack
+    const stack = useDrawersStack(drawerIds);
 
     useDidUpdate(() => {
         const openArray = Array.isArray(open) ? open : open ? [open] : [];
@@ -90,37 +90,37 @@ const ModalStack = ({
         });
     }, [stack]);
 
-    // Wrap each ManagedModal child with a <Modal>, registering it into the stack by ID
+    // Wrap each ManagedDrawer child with a <Drawer>, registering it into the stack by ID
     const wrappedChildren = childrenArray.map((child, index) => {
         const { type, props } = getChildLayout(child);
 
-        if (type !== 'ManagedModal') {
+        if (type !== 'ManagedDrawer') {
             throw new Error(
-                `StackModal only accepts 'ManagedModal' components as children. Received: '${type}'.`
+                `StackDrawer only accepts 'ManagedDrawer' components as children. Received: '${type}'.`
             );
         }
 
-        const { children: modalContent, ...modalProps } = props;
+        const { children: drawerContent, ...drawerProps } = props;
 
         return (
-            <Modal
+            <Drawer
                 key={index}
-                {...modalProps}
+                {...drawerProps}
                 {...stack.register(stringifyId(props.id))}
             >
                 {child}
-            </Modal>
+            </Drawer>
         );
     });
 
     return (
-        <Modal.Stack
+        <Drawer.Stack
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             {...others}
         >
             {wrappedChildren}
-        </Modal.Stack>
+        </Drawer.Stack>
     );
 };
 
-export default ModalStack;
+export default DrawerStack;

--- a/src/ts/components/core/drawer/DrawerStack.tsx
+++ b/src/ts/components/core/drawer/DrawerStack.tsx
@@ -18,7 +18,6 @@ interface DrawerStackProps extends DashBaseProps {
     closeAll?: boolean;
 }
 
-
 const DrawerStackComponent = createStackComponent({
     name: 'DrawerStack',
     useStackHook: useDrawersStack,

--- a/src/ts/components/core/drawer/DrawerStack.tsx
+++ b/src/ts/components/core/drawer/DrawerStack.tsx
@@ -1,15 +1,9 @@
+import { createStackComponent } from '../../../utils/stack-factory';
 import { Drawer, useDrawersStack } from '@mantine/core';
-import { useDidUpdate } from '@mantine/hooks';
-import React from 'react';
 import { DashBaseProps } from 'props/dash';
-import {
-    getChildLayout,
-    getLoadingState,
-    stringifyId,
-} from '../../../utils/dash3';
 
 interface Props extends DashBaseProps {
-    /** ManagedModel content */
+    /** ManagedDrawer content */
     children?: React.ReactElement[];
     /** Current opened state of each drawer.  Read only */
     state?: Record<string, boolean>;
@@ -24,103 +18,12 @@ interface Props extends DashBaseProps {
 }
 
 /** Use DrawerStack component to render multiple drawers at the same time.  */
-const DrawerStack = ({
-    children,
-    setProps,
-    loading_state,
-    open,
-    close,
-    toggle,
-    closeAll,
-    state,
-    ...others
-}: Props) => {
-    const childrenArray = React.Children.toArray(children);
-
-    // get ids of ManagedModels
-    const drawerIds = childrenArray
-        .map((child) => {
-            const { type, props } = getChildLayout(child);
-            return type === 'ManagedDrawer' ? stringifyId(props.id) : null;
-        })
-        .filter(Boolean) as string[];
-
-    // Initialize useDrawersStack
-    const stack = useDrawersStack(drawerIds);
-
-    useDidUpdate(() => {
-        const openArray = Array.isArray(open) ? open : open ? [open] : [];
-        if (openArray.length > 0) {
-            openArray.forEach((id) => stack.open(stringifyId(id)));
-        }
-    }, [open]);
-
-    useDidUpdate(() => {
-        const closeArray = Array.isArray(close) ? close : close ? [close] : [];
-        if (closeArray.length > 0) {
-            closeArray.forEach((id) => stack.close(stringifyId(id)));
-        }
-    }, [close]);
-
-    useDidUpdate(() => {
-        const toggleArray = Array.isArray(toggle)
-            ? toggle
-            : toggle
-              ? [toggle]
-              : [];
-        if (toggleArray.length > 0) {
-            toggleArray.forEach((id) => stack.toggle(stringifyId(id)));
-        }
-    }, [toggle]);
-
-    useDidUpdate(() => {
-        if (closeAll) {
-            stack.closeAll();
-        }
-    }, [closeAll]);
-
-    useDidUpdate(() => {
-        const currentState = stack.state;
-        setProps({
-            state: currentState,
-            toggle: null,
-            close: null,
-            open: null,
-            closeAll: false,
-        });
-    }, [stack]);
-
-    // Wrap each ManagedDrawer child with a <Drawer>, registering it into the stack by ID
-    const wrappedChildren = childrenArray.map((child, index) => {
-        const { type, props } = getChildLayout(child);
-
-        if (type !== 'ManagedDrawer') {
-            throw new Error(
-                `StackDrawer only accepts 'ManagedDrawer' components as children. Received: '${type}'.`
-            );
-        }
-
-        const { children: drawerContent, ...drawerProps } = props;
-
-        return (
-            <Drawer
-                key={index}
-                {...drawerProps}
-                {...stack.register(stringifyId(props.id))}
-            >
-                {child}
-            </Drawer>
-        );
-    });
-
-    return (
-        <Drawer.Stack
-            data-dash-is-loading={getLoadingState(loading_state) || undefined}
-            {...others}
-        >
-            {wrappedChildren}
-        </Drawer.Stack>
-    );
-};
+const DrawerStack = createStackComponent({
+    name: 'DrawerStack',
+    useStackHook: useDrawersStack,
+    OuterStack: Drawer.Stack,
+    InnerComponent: Drawer,
+    expectedType: 'ManagedDrawer',
+});
 
 export default DrawerStack;

--- a/src/ts/components/core/drawer/DrawerStack.tsx
+++ b/src/ts/components/core/drawer/DrawerStack.tsx
@@ -27,8 +27,8 @@ const DrawerStackComponent = createStackComponent({
 });
 
 /** Use DrawerStack to render multiple drawers at the same time */
-const DrawerStack = (props: DrawerStackProps) => {
-    return React.createElement(DrawerStackComponent, props);
-};
+const DrawerStack = (props: DrawerStackProps) => (
+    <DrawerStackComponent {...props} />
+);
 
 export default DrawerStack;

--- a/src/ts/components/core/drawer/ManagedDrawer.tsx
+++ b/src/ts/components/core/drawer/ManagedDrawer.tsx
@@ -3,11 +3,13 @@ import { DashBaseProps } from 'props/dash';
 import { ModalBaseOverlayProps, ModalBaseProps } from 'props/modal';
 import { StylesApiProps } from 'props/styles';
 import React, { useEffect, useState } from 'react';
-import { getLoadingState } from '../../utils/dash3';
+import { getLoadingState } from '../../../utils/dash3';
 
 type DrawerPosition = 'bottom' | 'left' | 'right' | 'top';
 
-interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
+interface Props extends StylesApiProps, Omit<ModalBaseProps, 'opened'>, Omit<DashBaseProps, 'id'> {
+    /** Unique ID to identify this component. Required for use with DrawerStack */
+    id: string;
     /** Side of the screen on which drawer will be opened, `'left'` by default */
     position?: DrawerPosition;
     /** Key of `theme.radius` or any valid CSS value to set `border-radius`, numbers are converted to rem, `0` by default */
@@ -28,35 +30,15 @@ interface Props extends StylesApiProps, ModalBaseProps, DashBaseProps {
     closeButtonProps?: object;
 }
 
-/** Drawer */
-const Drawer = ({
+
+/**  Managed Drawer for DrawerStack */
+const ManagedDrawer = ({
+    children,
     setProps,
     loading_state,
-    opened = false,
-    children,
     ...others
 }: Props) => {
-    const [open, setOpen] = useState(opened);
-
-    useEffect(() => {
-        setOpen(opened);
-    }, [opened]);
-
-    const onClose = () => {
-        setOpen(false);
-        setProps({ opened: false });
-    };
-
-    return (
-        <MantineDrawer
-            data-dash-is-loading={getLoadingState(loading_state) || undefined}
-            opened={open}
-            onClose={onClose}
-            {...others}
-        >
-            {children}
-        </MantineDrawer>
-    );
+    return <>{children}</>;
 };
 
-export default Drawer;
+export default ManagedDrawer;

--- a/src/ts/components/core/drawer/ManagedDrawer.tsx
+++ b/src/ts/components/core/drawer/ManagedDrawer.tsx
@@ -7,7 +7,10 @@ import { getLoadingState } from '../../../utils/dash3';
 
 type DrawerPosition = 'bottom' | 'left' | 'right' | 'top';
 
-interface Props extends StylesApiProps, Omit<ModalBaseProps, 'opened'>, Omit<DashBaseProps, 'id'> {
+interface Props
+    extends StylesApiProps,
+        Omit<ModalBaseProps, 'opened'>,
+        Omit<DashBaseProps, 'id'> {
     /** Unique ID to identify this component. Required for use with DrawerStack */
     id: string;
     /** Side of the screen on which drawer will be opened, `'left'` by default */
@@ -29,7 +32,6 @@ interface Props extends StylesApiProps, Omit<ModalBaseProps, 'opened'>, Omit<Das
     /** Props passed down to the close button */
     closeButtonProps?: object;
 }
-
 
 /**  Managed Drawer for DrawerStack */
 const ManagedDrawer = ({

--- a/src/ts/components/core/modal/ManagedModal.tsx
+++ b/src/ts/components/core/modal/ManagedModal.tsx
@@ -1,0 +1,26 @@
+import { Modal as MantineModal } from '@mantine/core';
+import { DashBaseProps } from 'props/dash';
+import { ModalProps } from 'props/modal';
+import { StylesApiProps } from 'props/styles';
+import React, { useEffect, useState } from 'react';
+import { getLoadingState } from '../../../utils/dash3';
+
+
+interface Props extends Omit<DashBaseProps, 'id'>, ModalProps, StylesApiProps {
+    /** Unique ID to identify this component. Required for use with StackModal */
+   id: string;
+}
+
+
+/**  Managed Model for StackModal */
+const ManagedModal = ({
+    children,
+    setProps,
+    loading_state,
+    opened=false,
+    ...others
+}: Props) => {
+    return <>{children}</>;
+};
+
+export default ManagedModal;

--- a/src/ts/components/core/modal/ManagedModal.tsx
+++ b/src/ts/components/core/modal/ManagedModal.tsx
@@ -5,12 +5,13 @@ import { StylesApiProps } from 'props/styles';
 import React, { useEffect, useState } from 'react';
 import { getLoadingState } from '../../../utils/dash3';
 
-
-interface Props extends Omit<DashBaseProps, 'id'>, Omit<ModalProps, 'opened'>, StylesApiProps {
+interface Props
+    extends Omit<DashBaseProps, 'id'>,
+        Omit<ModalProps, 'opened'>,
+        StylesApiProps {
     /** Unique ID to identify this component. Required for use with StackModal */
-   id: string;
+    id: string;
 }
-
 
 /**  Managed Model for StackModal */
 const ManagedModal = ({

--- a/src/ts/components/core/modal/ManagedModal.tsx
+++ b/src/ts/components/core/modal/ManagedModal.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { getLoadingState } from '../../../utils/dash3';
 
 
-interface Props extends Omit<DashBaseProps, 'id'>, ModalProps, StylesApiProps {
+interface Props extends Omit<DashBaseProps, 'id'>, Omit<ModalProps, 'opened'>, StylesApiProps {
     /** Unique ID to identify this component. Required for use with StackModal */
    id: string;
 }
@@ -17,7 +17,6 @@ const ManagedModal = ({
     children,
     setProps,
     loading_state,
-    opened=false,
     ...others
 }: Props) => {
     return <>{children}</>;

--- a/src/ts/components/core/modal/Modal.tsx
+++ b/src/ts/components/core/modal/Modal.tsx
@@ -3,7 +3,7 @@ import { DashBaseProps } from 'props/dash';
 import { ModalProps } from 'props/modal';
 import { StylesApiProps } from 'props/styles';
 import React, { useEffect, useState } from 'react';
-import { getLoadingState } from '../../utils/dash3';
+import { getLoadingState } from '../../../utils/dash3';
 
 interface Props extends ModalProps, StylesApiProps, DashBaseProps {}
 

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -54,7 +54,6 @@ const ModalStack = ({
         if (openArray.length > 0) {
             openArray.forEach((id) => stack.open(stringifyId(id)));
         }
-        setProps({ open: null });
     }, [open]);
 
     useDidUpdate(() => {
@@ -62,7 +61,6 @@ const ModalStack = ({
         if (closeArray.length > 0) {
             closeArray.forEach((id) => stack.close(stringifyId(id)));
         }
-        setProps({ close: null });
     }, [close]);
 
     useDidUpdate(() => {
@@ -74,19 +72,23 @@ const ModalStack = ({
         if (toggleArray.length > 0) {
             toggleArray.forEach((id) => stack.toggle(stringifyId(id)));
         }
-        setProps({ toggle: null });
     }, [toggle]);
 
     useDidUpdate(() => {
         if (closeAll) {
             stack.closeAll();
-            setProps({ closeAll: false });
         }
     }, [closeAll]);
 
     useDidUpdate(() => {
         const currentState = stack.state;
-        setProps({ state: currentState });
+        setProps({
+            state: currentState,
+            toggle: null,
+            close: null,
+            open: null,
+            closeAll: false,
+        });
     }, [stack]);
 
     // Wrap each ManagedModal child with a <Modal>, registering it into the stack by ID

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -1,0 +1,102 @@
+import { Modal, useModalsStack } from '@mantine/core';
+import { useDidUpdate } from '@mantine/hooks';
+import React from 'react';
+import { DashBaseProps } from 'props/dash';
+import { StylesApiProps } from 'props/styles';
+import {
+    getChildLayout,
+    getLoadingState,
+    stringifyId,
+} from '../../../utils/dash3';
+
+interface Props extends DashBaseProps {
+    /** ManagedModel content */
+    children?: React.ReactElement[];
+    /** Current opened state of each modal.  Read only */
+    state?: Record<string, boolean>;
+    /** Opens modal with the given id */
+    open?: string;
+    /** Toggles modal with the given id */
+    toggle?: string;
+    /** Closes all modals in the StackModal */
+    closeAll?: boolean;
+}
+
+/** Use ModalStack component to render multiple modals at the same time.  */
+const ModalStack = ({
+    children,
+    setProps,
+    loading_state,
+    open,
+    toggle,
+    closeAll,
+    ...others
+}: Props) => {
+    const childrenArray = React.Children.toArray(children);
+
+    // get ids of ManagedModels
+    const modalIds = childrenArray
+        .map((child) => {
+            const { type, props } = getChildLayout(child);
+            return type === 'ManagedModal' ? stringifyId(props.id) : null;
+        })
+        .filter(Boolean) as string[];
+
+    // Initialize useModalsStack
+    const stack = useModalsStack(modalIds);
+
+    useDidUpdate(() => {
+        if (open) {
+            stack.open(stringifyId(open));
+            setProps?.({ open: null });
+        }
+    }, [open]);
+
+    useDidUpdate(() => {
+        if (toggle) {
+            stack.toggle(stringifyId(toggle));
+            setProps?.({ toggle: null });
+        }
+    }, [toggle]);
+
+    useDidUpdate(() => {
+        if (closeAll) {
+            stack.closeAll();
+            setProps?.({ closeAll: false });
+        }
+    }, [closeAll]);
+
+    // Wrap each ManagedModal child with a <Modal>, registering it into the stack by ID
+    const wrappedChildren = childrenArray.map((child, index) => {
+        const { type, props } = getChildLayout(child);
+
+        if (type !== 'ManagedModal') {
+            throw new Error(
+                `StackModal only accepts 'ManagedModal' components as children. Received: '${type}'.`
+            );
+        }
+
+        const { children: modalContent, ...modalProps } = props;
+
+        return (
+            <Modal
+                key={index}
+                {...modalProps}
+                {...stack.register(stringifyId(props.id))}
+            >
+                {child}
+            </Modal>
+        );
+    });
+
+    return (
+        <Modal.Stack
+            data-dash-is-loading={getLoadingState(loading_state) || undefined}
+            {...others}
+        >
+            {wrappedChildren}
+        </Modal.Stack>
+    );
+};
+
+export default ModalStack;

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -30,6 +30,7 @@ const ModalStackComponent = createStackComponent({
 const ModalStack = (props: ModalStackProps) => (
     <ModalStackComponent {...props} />
 );
+
 ModalStack.displayName = 'ModalStack';
 
 export default ModalStack;

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -1,10 +1,12 @@
-import { createStackComponent } from '../../../utils/stack-factory';
+import React from 'react';
 import { Modal, useModalsStack } from '@mantine/core';
+import { createStackComponent } from '../../../utils/stack-factory';
 import { DashBaseProps } from 'props/dash';
-interface Props extends DashBaseProps {
-    /** ManagedModel content */
+
+interface ModalStackProps extends DashBaseProps {
+    /** ManagedModal content */
     children?: React.ReactElement[];
-    /** Current opened state of each modal.  Read only */
+    /** Current opened state of each modal. Read only */
     state?: Record<string, boolean>;
     /** Opens one or more modals by ID. Accepts a single ID (string or dict) or a list of IDs. */
     open?: string | Record<string, any> | (string | Record<string, any>)[];
@@ -16,13 +18,16 @@ interface Props extends DashBaseProps {
     closeAll?: boolean;
 }
 
-/** Use ModalStack component to render multiple modals at the same time.  */
-const ModalStack = createStackComponent({
+const ModalStackComponent = createStackComponent({
     name: 'ModalStack',
     useStackHook: useModalsStack,
     OuterStack: Modal.Stack,
     InnerComponent: Modal,
     expectedType: 'ManagedModal',
 });
+
+/** Use ModalStack component to render multiple modals at the same time.*/
+const ModalStack = (props: ModalStackProps) => <ModalStackComponent {...props} />;
+ModalStack.displayName = 'ModalStack';
 
 export default ModalStack;

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -1,13 +1,6 @@
+import { createStackComponent } from '../../../utils/stack-factory';
 import { Modal, useModalsStack } from '@mantine/core';
-import { useDidUpdate } from '@mantine/hooks';
-import React from 'react';
 import { DashBaseProps } from 'props/dash';
-import {
-    getChildLayout,
-    getLoadingState,
-    stringifyId,
-} from '../../../utils/dash3';
-
 interface Props extends DashBaseProps {
     /** ManagedModel content */
     children?: React.ReactElement[];
@@ -24,103 +17,12 @@ interface Props extends DashBaseProps {
 }
 
 /** Use ModalStack component to render multiple modals at the same time.  */
-const ModalStack = ({
-    children,
-    setProps,
-    loading_state,
-    open,
-    close,
-    toggle,
-    closeAll,
-    state,
-    ...others
-}: Props) => {
-    const childrenArray = React.Children.toArray(children);
-
-    // get ids of ManagedModels
-    const modalIds = childrenArray
-        .map((child) => {
-            const { type, props } = getChildLayout(child);
-            return type === 'ManagedModal' ? stringifyId(props.id) : null;
-        })
-        .filter(Boolean) as string[];
-
-    // Initialize useModalsStack
-    const stack = useModalsStack(modalIds);
-
-    useDidUpdate(() => {
-        const openArray = Array.isArray(open) ? open : open ? [open] : [];
-        if (openArray.length > 0) {
-            openArray.forEach((id) => stack.open(stringifyId(id)));
-        }
-    }, [open]);
-
-    useDidUpdate(() => {
-        const closeArray = Array.isArray(close) ? close : close ? [close] : [];
-        if (closeArray.length > 0) {
-            closeArray.forEach((id) => stack.close(stringifyId(id)));
-        }
-    }, [close]);
-
-    useDidUpdate(() => {
-        const toggleArray = Array.isArray(toggle)
-            ? toggle
-            : toggle
-              ? [toggle]
-              : [];
-        if (toggleArray.length > 0) {
-            toggleArray.forEach((id) => stack.toggle(stringifyId(id)));
-        }
-    }, [toggle]);
-
-    useDidUpdate(() => {
-        if (closeAll) {
-            stack.closeAll();
-        }
-    }, [closeAll]);
-
-    useDidUpdate(() => {
-        const currentState = stack.state;
-        setProps({
-            state: currentState,
-            toggle: null,
-            close: null,
-            open: null,
-            closeAll: false,
-        });
-    }, [stack]);
-
-    // Wrap each ManagedModal child with a <Modal>, registering it into the stack by ID
-    const wrappedChildren = childrenArray.map((child, index) => {
-        const { type, props } = getChildLayout(child);
-
-        if (type !== 'ManagedModal') {
-            throw new Error(
-                `StackModal only accepts 'ManagedModal' components as children. Received: '${type}'.`
-            );
-        }
-
-        const { children: modalContent, ...modalProps } = props;
-
-        return (
-            <Modal
-                key={index}
-                {...modalProps}
-                {...stack.register(stringifyId(props.id))}
-            >
-                {child}
-            </Modal>
-        );
-    });
-
-    return (
-        <Modal.Stack
-            data-dash-is-loading={getLoadingState(loading_state) || undefined}
-            {...others}
-        >
-            {wrappedChildren}
-        </Modal.Stack>
-    );
-};
+const ModalStack = createStackComponent({
+    name: 'ModalStack',
+    useStackHook: useModalsStack,
+    OuterStack: Modal.Stack,
+    InnerComponent: Modal,
+    expectedType: 'ManagedModal',
+});
 
 export default ModalStack;

--- a/src/ts/components/core/modal/ModalStack.tsx
+++ b/src/ts/components/core/modal/ModalStack.tsx
@@ -27,7 +27,9 @@ const ModalStackComponent = createStackComponent({
 });
 
 /** Use ModalStack component to render multiple modals at the same time.*/
-const ModalStack = (props: ModalStackProps) => <ModalStackComponent {...props} />;
+const ModalStack = (props: ModalStackProps) => (
+    <ModalStackComponent {...props} />
+);
 ModalStack.displayName = 'ModalStack';
 
 export default ModalStack;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -33,7 +33,9 @@ import Kbd from './components/core/Kbd';
 import Loader from './components/core/Loader';
 import LoadingOverlay from './components/core/LoadingOverlay';
 import Mark from './components/core/Mark';
-import Modal from './components/core/Modal';
+import Modal from './components/core/modal/Modal';
+import ModalStack from './components/core/modal/ModalStack';
+import ManagedModal from './components/core/modal/ManagedModal';
 import NavLink from './components/core/NavLink';
 import NumberFormatter from './components/core/NumberFormatter';
 import Overlay from './components/core/Overlay';
@@ -264,6 +266,8 @@ export {
     SubMenuItem,
     SubMenuTarget,
     Modal,
+    ManagedModal,
+    ModalStack,
     MonthPickerInput,
     MultiSelect,
     NavLink,

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -22,7 +22,9 @@ import Code from './components/core/Code';
 import Collapse from './components/core/Collapse';
 import Container from './components/core/Container';
 import Divider from './components/core/Divider';
-import Drawer from './components/core/Drawer';
+import Drawer from './components/core/drawer/Drawer';
+import DrawerStack from './components/core/drawer/DrawerStack';
+import ManagedDrawer from './components/core/drawer/ManagedDrawer';
 import Fieldset from './components/core/Fieldset';
 import Flex from './components/core/Flex';
 import Group from './components/core/Group';
@@ -233,6 +235,8 @@ export {
     Divider,
     DonutChart,
     Drawer,
+    DrawerStack,
+    ManagedDrawer,
     Fieldset,
     Flex,
     FloatingTooltip,

--- a/src/ts/utils/stack-factory.ts
+++ b/src/ts/utils/stack-factory.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+import { useDidUpdate } from '@mantine/hooks';
+import {
+    getChildLayout,
+    getLoadingState,
+    stringifyId,
+} from './dash3';
+import { DashBaseProps } from 'props/dash';
+
+interface StackProps extends DashBaseProps {
+    children?: React.ReactElement[];
+    state?: Record<string, boolean>;
+    open?: string | Record<string, any> | (string | Record<string, any>)[];
+    close?: string | Record<string, any> | (string | Record<string, any>)[];
+    toggle?: string | Record<string, any> | (string | Record<string, any>)[];
+    closeAll?: boolean;
+}
+
+export function createStackComponent({
+    name,
+    useStackHook,
+    OuterStack,
+    InnerComponent,
+    expectedType,
+}: {
+    name: string;
+    useStackHook: (ids: string[]) => any;
+    OuterStack: React.ComponentType<any>;
+    InnerComponent: React.ComponentType<any>;
+    expectedType: string;
+}) {
+    const StackComponent = ({
+        children,
+        setProps,
+        loading_state,
+        open,
+        close,
+        toggle,
+        closeAll,
+        state,
+        ...others
+    }: StackProps) => {
+        const childrenArray = React.Children.toArray(children);
+
+        const ids = childrenArray
+            .map((child) => {
+                const { type, props } = getChildLayout(child);
+                return type === expectedType ? stringifyId(props.id) : null;
+            })
+            .filter(Boolean) as string[];
+
+        const stack = useStackHook(ids);
+
+        useDidUpdate(() => {
+            const openArray = Array.isArray(open) ? open : open ? [open] : [];
+            openArray.forEach((id) => stack.open(stringifyId(id)));
+        }, [open]);
+
+        useDidUpdate(() => {
+            const closeArray = Array.isArray(close)
+                ? close
+                : close
+                ? [close]
+                : [];
+            closeArray.forEach((id) => stack.close(stringifyId(id)));
+        }, [close]);
+
+        useDidUpdate(() => {
+            const toggleArray = Array.isArray(toggle)
+                ? toggle
+                : toggle
+                ? [toggle]
+                : [];
+            toggleArray.forEach((id) => stack.toggle(stringifyId(id)));
+        }, [toggle]);
+
+        useDidUpdate(() => {
+            if (closeAll) {
+                stack.closeAll();
+            }
+        }, [closeAll]);
+
+        useDidUpdate(() => {
+            setProps?.({
+                state: stack.state,
+                toggle: null,
+                close: null,
+                open: null,
+                closeAll: false,
+            });
+        }, [stack.state]);
+
+        const wrappedChildren = childrenArray.map((child, index) => {
+            const { type, props } = getChildLayout(child);
+            if (type !== expectedType) {
+                throw new Error(
+                    `${name} only accepts '${expectedType}' components. Received: '${type}'.`
+                );
+            }
+
+            const { children: content, ...innerProps } = props;
+            return React.createElement(
+                InnerComponent,
+                {
+                    key: index,
+                    ...innerProps,
+                    ...stack.register(stringifyId(props.id)),
+                },
+                child
+            );
+        });
+
+        return React.createElement(
+            OuterStack,
+            {
+                'data-dash-is-loading': getLoadingState(loading_state) || undefined,
+                ...others,
+            },
+            wrappedChildren
+        );
+    };
+
+    StackComponent.displayName = name;
+    return StackComponent;
+}

--- a/src/ts/utils/stack-factory.tsx
+++ b/src/ts/utils/stack-factory.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { useDidUpdate } from '@mantine/hooks';
-import {
-    getChildLayout,
-    getLoadingState,
-    stringifyId,
-} from './dash3';
+import { getChildLayout, getLoadingState, stringifyId } from './dash3';
 import { DashBaseProps } from 'props/dash';
 
 interface StackProps extends DashBaseProps {
@@ -60,8 +56,8 @@ export function createStackComponent({
             const closeArray = Array.isArray(close)
                 ? close
                 : close
-                ? [close]
-                : [];
+                  ? [close]
+                  : [];
             closeArray.forEach((id) => stack.close(stringifyId(id)));
         }, [close]);
 
@@ -69,8 +65,8 @@ export function createStackComponent({
             const toggleArray = Array.isArray(toggle)
                 ? toggle
                 : toggle
-                ? [toggle]
-                : [];
+                  ? [toggle]
+                  : [];
             toggleArray.forEach((id) => stack.toggle(stringifyId(id)));
         }, [toggle]);
 
@@ -99,24 +95,27 @@ export function createStackComponent({
             }
 
             const { children: content, ...innerProps } = props;
-            return React.createElement(
-                InnerComponent,
-                {
-                    key: index,
-                    ...innerProps,
-                    ...stack.register(stringifyId(props.id)),
-                },
-                child
+
+            return (
+                <InnerComponent
+                    key={index}
+                    {...innerProps}
+                    {...stack.register(stringifyId(props.id))}
+                >
+                    {child}
+                </InnerComponent>
             );
         });
 
-        return React.createElement(
-            OuterStack,
-            {
-                'data-dash-is-loading': getLoadingState(loading_state) || undefined,
-                ...others,
-            },
-            wrappedChildren
+        return (
+            <OuterStack
+                data-dash-is-loading={
+                    getLoadingState(loading_state) || undefined
+                }
+                {...others}
+            >
+                {wrappedChildren}
+            </OuterStack>
         );
     };
 

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -1,5 +1,6 @@
-from dash import Dash, html, Output, Input, State, _dash_renderer
+from dash import Dash, html, Output, Input, State, _dash_renderer, ctx, no_update
 import dash_mantine_components as dmc
+from selenium.webdriver.common.keys import Keys
 
 _dash_renderer._set_react_version("18.2.0")
 
@@ -48,3 +49,84 @@ def test_001mo_modal(dash_duo):
     modal_close_btn.click()
 
     assert dash_duo.get_logs() == []
+
+
+
+
+def test_002mo_modalstack(dash_duo):
+    app = Dash(__name__)
+
+    component = dmc.ModalStack(
+        children=[
+            dmc.ManagedModal(title="first", id="first", children=[dmc.Button("Modal Btn", id="btn")]),
+            dmc.ManagedModal(title="second", id="second")
+        ],
+        id="stack-modal"
+    )
+
+    app.layout = dmc.MantineProvider([
+        dmc.Button("open model 1 & 2", id="btn1", n_clicks=0),
+        dmc.Button("open model 2", id="btn2", n_clicks=0),
+        component,
+        dmc.Text(id="out")
+    ])
+
+    @app.callback(
+        Output("out", "children"),
+        Input("btn", "n_clicks"),
+        Input("stack-modal", "state")
+    )
+    def update(n, s):
+        return f"clicked {n}, state {s}"
+
+    @app.callback(
+        Output("stack-modal", "open"),
+        Input("btn1", "n_clicks"),
+        Input("btn2", "n_clicks")
+    )
+    def update(n, n2):
+        if ctx.triggered_id == "btn1":
+            return ["first", "second"]
+        if ctx.triggered_id == "btn2":
+            return "second"
+        return no_update
+
+    dash_duo.start_server(app)
+
+    btn1 = dash_duo.find_element("#btn1")
+    btn2 = dash_duo.find_element("#btn2")
+
+    # Click first button (open both modals)
+    btn1.click()
+    dash_duo.wait_for_text_to_equal("#out", "clicked None, state {'first': True, 'second': True}")
+
+
+    # Send ESCAPE key to close top modal (second)
+    btn1.send_keys(Keys.ESCAPE)
+
+    # Wait for state update to reflect second modal closed
+    dash_duo.wait_for_text_to_equal(
+        "#out", "clicked None, state {'first': True, 'second': False}"
+    )
+
+
+    # Click the button inside the modal
+    modal_btn = dash_duo.find_element("#btn")
+    modal_btn.click()
+    dash_duo.wait_for_text_to_equal("#out", "clicked 1, state {'first': True, 'second': False}")
+
+    # Send ESCAPE key to close top modal (first)
+    btn1.send_keys(Keys.ESCAPE)
+
+    # Wait for state update to reflect first modal closed
+    dash_duo.wait_for_text_to_equal(
+        "#out", "clicked 1, state {'first': False, 'second': False}"
+    )
+
+    # Click second button (only second modal open)
+    btn2.click()
+    dash_duo.wait_for_text_to_equal("#out", "clicked 1, state {'first': False, 'second': True}")
+
+
+    assert dash_duo.get_logs() == []
+


### PR DESCRIPTION
Closes #603 

This PR adds [Modal Stack](https://mantine.dev/core/modal/#modalstack)  and [Drawer Stack](https://mantine.dev/core/drawer/#drawerstack)

Todo
- [x] Add DrawerStack
- [x] Add tests
- [x] Add Changelog
- [x] Docs  See [dmc-docs pr 210](https://github.com/snehilvj/dmc-docs/pull/210)

