### PR TITLE
Fix Slider and RangeSlider when min or max changes in a callback

### DIFF
--- a/src/ts/components/core/slider/RangeSlider.tsx
+++ b/src/ts/components/core/slider/RangeSlider.tsx
@@ -102,6 +102,7 @@ const RangeSlider = ({
 
     return (
         <MantineRangeSlider
+            key={`${others.min}-${others.max}`}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             {...parseFuncProps('RangeSlider', others)}
             value={val}

--- a/src/ts/components/core/slider/Slider.tsx
+++ b/src/ts/components/core/slider/Slider.tsx
@@ -94,6 +94,7 @@ const Slider = ({
 
     return (
         <MantineSlider
+            key={`${others.min}-${others.max}`}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             {...parseFuncProps('Slider', others)}
             value={val}


### PR DESCRIPTION
Fixes #615 

Dragging the handle causes `MantineSlider` to calculate the new value based on the handle’s position. However,  the `MantineSlider` is storing the drag’s position as a percent of the old range.   

Using  a key based on the `min` and `max` remounts the slider whenever min or max changes, resetting the drag state.