### PR TITLE
update data and value together - fixes #634

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- fixes 'MultiSelectandSelectso that changes to thedataandvalue` are batched so they only trigger a single callback. #637 by @AnnMarieW
+- fixes `MultiSelect` and `Select` so that changes to the `data` and `value` are batched so they only trigger a single callback. #637 by @AnnMarieW
 
 # 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Unreleased
+
+### Fixed
+
+- fixes 'MultiSelectandSelectso that changes to thedataandvalue` are batched so they only trigger a single callback. #637 by @AnnMarieW
+
 # 2.2.0
 
 See details and examples in the [DMC 2.2.0 Release Announcement](https://www.dash-mantine-components.com/release-2-2-0)

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -85,20 +85,6 @@ const MultiSelect = ({
         }
     }, [debounced]);
 
-    useDidUpdate(() => {
-        const newOptions = Array.isArray(data) ? data : [];
-        const rawValue = Array.isArray(value) ? value : [];
-        const newSelected = filterSelected(newOptions, rawValue) ?? [];
-
-        setOptions(newOptions);
-        setSelected(newSelected);
-
-        setProps({
-            data: newOptions,
-            value: newSelected,
-        });
-    }, [data, value]);
-
 
     const handleKeyDown = (ev) => {
         if (ev.key === 'Enter') {
@@ -115,6 +101,19 @@ const MultiSelect = ({
             ...(debounce === true && { value: selected }),
         });
     };
+
+     useDidUpdate(() => {
+        const newOptions = Array.isArray(data) ? data : [];
+        const rawValue = Array.isArray(value) ? value : [];
+        const newSelected = filterSelected(newOptions, rawValue) ?? [];
+
+        setOptions(newOptions);
+        setSelected(newSelected);
+
+        setProps({
+            value: newSelected,
+        });
+    }, [data, value]);
 
     const handleSearchChange = (newSearchVal) => {
         setProps({ searchValue: newSearchVal });

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -102,18 +102,21 @@ const MultiSelect = ({
         });
     };
 
-     useDidUpdate(() => {
-        const newOptions = Array.isArray(data) ? data : [];
-        const rawValue = Array.isArray(value) ? value : [];
-        const newSelected = filterSelected(newOptions, rawValue) ?? [];
 
-        setOptions(newOptions);
-        setSelected(newSelected);
+   useDidUpdate(() => {
+      const newOptions = Array.isArray(data) ? data : [];
+      setOptions(newOptions);
 
-        setProps({
-            value: newSelected,
-        });
-    }, [data, value]);
+      const rawValue = Array.isArray(value) ? value : [];
+      const newSelected = filterSelected(newOptions, rawValue) ?? [];
+      setSelected(newSelected);
+
+      setProps({ value: newSelected });
+    }, [data]);
+
+    useDidUpdate(() => {
+        setSelected(value ?? []);
+    }, [value]);
 
     const handleSearchChange = (newSearchVal) => {
         setProps({ searchValue: newSearchVal });

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -85,6 +85,21 @@ const MultiSelect = ({
         }
     }, [debounced]);
 
+    useDidUpdate(() => {
+        const newOptions = Array.isArray(data) ? data : [];
+        const rawValue = Array.isArray(value) ? value : [];
+        const newSelected = filterSelected(newOptions, rawValue) ?? [];
+
+        setOptions(newOptions);
+        setSelected(newSelected);
+
+        setProps({
+            data: newOptions,
+            value: newSelected,
+        });
+    }, [data, value]);
+
+
     const handleKeyDown = (ev) => {
         if (ev.key === 'Enter') {
             setProps({
@@ -104,20 +119,6 @@ const MultiSelect = ({
     const handleSearchChange = (newSearchVal) => {
         setProps({ searchValue: newSearchVal });
     };
-
-    useDidUpdate(() => {
-        setOptions(data);
-        const filteredSelected = filterSelected(data, selected);
-        setSelected(filteredSelected ?? []);
-    }, [data]);
-
-    useDidUpdate(() => {
-        setSelected(value ?? []);
-    }, [value]);
-
-    useDidUpdate(() => {
-        setProps({ data: options });
-    }, [options]);
 
     return (
         <div ref={ref}>

--- a/src/ts/components/core/combobox/Select.tsx
+++ b/src/ts/components/core/combobox/Select.tsx
@@ -94,18 +94,17 @@ const Select = ({
     };
 
     useDidUpdate(() => {
-        setOptions(data);
-        const filteredSelected = filterSelected(data, selected);
-        setSelected(filteredSelected);
-    }, [data]);
+        const newOptions = Array.isArray(data) ? data : [];
+        const newSelected = filterSelected(newOptions, value);
 
-    useDidUpdate(() => {
-        setSelected(value);
-    }, [value]);
+        setOptions(newOptions);
+        setSelected(newSelected);
 
-    useDidUpdate(() => {
-        setProps({ data: options });
-    }, [options]);
+        setProps({
+            value: newSelected,
+        });
+    }, [data, value]);
+
 
     useDidUpdate(() => {
         setProps({ searchValue: searchVal });

--- a/src/ts/components/core/combobox/Select.tsx
+++ b/src/ts/components/core/combobox/Select.tsx
@@ -103,8 +103,11 @@ const Select = ({
         setProps({
             value: newSelected,
         });
-    }, [data, value]);
+    }, [data]);
 
+    useDidUpdate(() => {
+        setSelected(value);
+    }, [value]);
 
     useDidUpdate(() => {
         setProps({ searchValue: searchVal });

--- a/tests/combobox/test_multi_select.py
+++ b/tests/combobox/test_multi_select.py
@@ -1,4 +1,4 @@
-from dash import Dash, html, Output, Input, _dash_renderer, ctx
+from dash import Dash, html, Output, Input, State, _dash_renderer, ctx
 import dash_mantine_components as dmc
 from flaky import flaky
 import pytest
@@ -118,16 +118,12 @@ def test_003mu_multi_select(dash_duo):
             dmc.Text(id="dmc-triggered"),
             dmc.MultiSelect(
                 id="dmc-dropdown",
-                data = ["three", "four", "five"],
-                value=["three", "four"]
+                data=["three", "four", "five"],
+                value=["three", "four"],
             ),
-            dmc.Button(
-                "change options",
-                id="change-options",
-            ),
+            dmc.Button("change options", id="change-options"),
         ]
     )
-
 
     @app.callback(
         Output("dmc-dropdown", "data"),
@@ -137,23 +133,33 @@ def test_003mu_multi_select(dash_duo):
     def change_options(n_clicks):
         return ["one", "two", "three"]
 
-
+    # accumulate triggered history instead of overwriting
     @app.callback(
         Output("dmc-triggered", "children"),
         Input("dmc-dropdown", "value"),
         Input("dmc-dropdown", "data"),
+        State("dmc-triggered", "children"),
     )
-    def dmc_select_value(value, data):
-        return str(ctx.triggered)
-
+    def dmc_select_value(value, data, prev):
+        prev = prev or ""
+        return prev + "|" + str(ctx.triggered)
 
     dash_duo.start_server(app)
-    # Wait for the app to load
-    dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': '.', 'value': None}]" )
+
+    # wait for app to load
+    dash_duo.wait_for_text_to_equal(
+        "#dmc-triggered", "|[{'prop_id': '.', 'value': None}]"
+    )
 
     dash_duo.find_element("#change-options").click()
 
-    dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, {'prop_id': 'dmc-dropdown.value', 'value': ['three']}]")
+    # There should be only one additional appended entry (checks that callback is triggered only once)
+    dash_duo.wait_for_text_to_equal(
+        "#dmc-triggered",
+        "|[{'prop_id': '.', 'value': None}]"
+        + "|[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, "
+        + "{'prop_id': 'dmc-dropdown.value', 'value': ['three']}]",
+    )
 
     assert dash_duo.get_logs() == []
 

--- a/tests/combobox/test_select.py
+++ b/tests/combobox/test_select.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.keys import Keys
-from dash import Dash, html, callback, Output, Input, _dash_renderer, ctx
+from dash import Dash, html, callback, Output, Input, State, _dash_renderer, ctx
 import dash_mantine_components as dmc
 
 _dash_renderer._set_react_version("18.2.0")
@@ -165,6 +165,57 @@ def test_003se_select(dash_duo):
     assert dash_duo.get_logs() == []
 
 
+#
+# # check that value and data update at the same time when data is updated
+# def test_004se_select(dash_duo):
+#     app = Dash()
+#
+#     app.layout = dmc.MantineProvider(
+#         [
+#             dmc.Text(id="dmc-triggered"),
+#             dmc.Select(
+#                 id="dmc-dropdown",
+#                 data = ["three", "four", "five"],
+#                 value="four"
+#             ),
+#             dmc.Button(
+#                 "change options",
+#                 id="change-options",
+#             ),
+#         ]
+#     )
+#
+#
+#     @app.callback(
+#         Output("dmc-dropdown", "data"),
+#         Input("change-options", "n_clicks"),
+#         prevent_initial_call=True,
+#     )
+#     def change_options(n_clicks):
+#         return ["one", "two", "three"]
+#
+#
+#     @app.callback(
+#         Output("dmc-triggered", "children"),
+#         Input("dmc-dropdown", "value"),
+#         Input("dmc-dropdown", "data"),
+#     )
+#     def dmc_select_value(value, data):
+#         return str(ctx.triggered)
+#
+#
+#     dash_duo.start_server(app)
+#     # Wait for the app to load
+#     dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': '.', 'value': None}]" )
+#
+#     dash_duo.find_element("#change-options").click()
+#
+#     dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, {'prop_id': 'dmc-dropdown.value', 'value': None}]")
+#
+#     assert dash_duo.get_logs() == []
+#
+#
+
 
 # check that value and data update at the same time when data is updated
 def test_004se_select(dash_duo):
@@ -175,16 +226,12 @@ def test_004se_select(dash_duo):
             dmc.Text(id="dmc-triggered"),
             dmc.Select(
                 id="dmc-dropdown",
-                data = ["three", "four", "five"],
-                value="four"
+                data=["three", "four", "five"],
+                value="four",
             ),
-            dmc.Button(
-                "change options",
-                id="change-options",
-            ),
+            dmc.Button("change options", id="change-options"),
         ]
     )
-
 
     @app.callback(
         Output("dmc-dropdown", "data"),
@@ -194,29 +241,35 @@ def test_004se_select(dash_duo):
     def change_options(n_clicks):
         return ["one", "two", "three"]
 
-
+    # accumulate triggered history instead of overwriting
     @app.callback(
         Output("dmc-triggered", "children"),
         Input("dmc-dropdown", "value"),
         Input("dmc-dropdown", "data"),
+        State("dmc-triggered", "children"),
     )
-    def dmc_select_value(value, data):
-        return str(ctx.triggered)
-
+    def dmc_select_value(value, data, prev):
+        prev = prev or ""
+        return prev + "|" + str(ctx.triggered)
 
     dash_duo.start_server(app)
-    # Wait for the app to load
-    dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': '.', 'value': None}]" )
+
+    # Initial trigger on app load
+    dash_duo.wait_for_text_to_equal(
+        "#dmc-triggered", "|[{'prop_id': '.', 'value': None}]"
+    )
 
     dash_duo.find_element("#change-options").click()
 
-    dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, {'prop_id': 'dmc-dropdown.value', 'value': None}]")
+    # Expect only one new entry appended -- to show callback triggerd only once
+    dash_duo.wait_for_text_to_equal(
+        "#dmc-triggered",
+        "|[{'prop_id': '.', 'value': None}]"
+        + "|[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, "
+        + "{'prop_id': 'dmc-dropdown.value', 'value': None}]",
+    )
 
     assert dash_duo.get_logs() == []
-
-
-
-
 
 
 

--- a/tests/combobox/test_select.py
+++ b/tests/combobox/test_select.py
@@ -165,58 +165,6 @@ def test_003se_select(dash_duo):
     assert dash_duo.get_logs() == []
 
 
-#
-# # check that value and data update at the same time when data is updated
-# def test_004se_select(dash_duo):
-#     app = Dash()
-#
-#     app.layout = dmc.MantineProvider(
-#         [
-#             dmc.Text(id="dmc-triggered"),
-#             dmc.Select(
-#                 id="dmc-dropdown",
-#                 data = ["three", "four", "five"],
-#                 value="four"
-#             ),
-#             dmc.Button(
-#                 "change options",
-#                 id="change-options",
-#             ),
-#         ]
-#     )
-#
-#
-#     @app.callback(
-#         Output("dmc-dropdown", "data"),
-#         Input("change-options", "n_clicks"),
-#         prevent_initial_call=True,
-#     )
-#     def change_options(n_clicks):
-#         return ["one", "two", "three"]
-#
-#
-#     @app.callback(
-#         Output("dmc-triggered", "children"),
-#         Input("dmc-dropdown", "value"),
-#         Input("dmc-dropdown", "data"),
-#     )
-#     def dmc_select_value(value, data):
-#         return str(ctx.triggered)
-#
-#
-#     dash_duo.start_server(app)
-#     # Wait for the app to load
-#     dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': '.', 'value': None}]" )
-#
-#     dash_duo.find_element("#change-options").click()
-#
-#     dash_duo.wait_for_text_to_equal("#dmc-triggered", "[{'prop_id': 'dmc-dropdown.data', 'value': ['one', 'two', 'three']}, {'prop_id': 'dmc-dropdown.value', 'value': None}]")
-#
-#     assert dash_duo.get_logs() == []
-#
-#
-
-
 # check that value and data update at the same time when data is updated
 def test_004se_select(dash_duo):
     app = Dash()


### PR DESCRIPTION
closes #634 

- fixes 'MultiSelect` and `Select` so that changes to the `data` and `value` are batched so they only trigger a single callback.
