### PR TITLE
add default valueFormatter

### DIFF
--- a/src/ts/components/charts/fragments/BarChart.tsx
+++ b/src/ts/components/charts/fragments/BarChart.tsx
@@ -94,7 +94,7 @@ const BarChart = ({
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             barChartProps={newProps}
             barProps={barPropsFunction}
-            valueFormatter={resolveProp(valueFormatter)}
+            valueFormatter={resolveProp(valueFormatter) || ((value: number) => value.toString())}
             tooltipProps={resolveProp(tooltipProps)}
             getBarColor={resolveProp(getBarColor)}
             {...others}


### PR DESCRIPTION
This bug was reported on our discord:
 - When `withBarValueLable=True` and there is no `valueFormatter` defined, the bar labels do not render.

I checked this in a pure Mantine app and got the same results, so it's likely an upstream bug.  But it's easy to fix here by providing a default `valueFormatter` .  

This sample app works correctly with the update in this PR:



```python

import dash_mantine_components as dmc
from dash import Dash

app = Dash()

data = [
    {"month": "January", "Smartphones": 1200, "Laptops": 900, "Tablets": 200},
    {"month": "February", "Smartphones": 1900, "Laptops": 1200, "Tablets": 400},
    {"month": "March", "Smartphones": 400, "Laptops": 1000, "Tablets": 200},
    {"month": "April", "Smartphones": 1000, "Laptops": 200, "Tablets": 800},
    {"month": "May", "Smartphones": 800, "Laptops": 1400, "Tablets": 1200},
    {"month": "June", "Smartphones": 750, "Laptops": 600, "Tablets": 1000}
]

component = dmc.BarChart(
    h=300,
    dataKey="month",
    data=data,
    withBarValueLabel=True,
    valueLabelProps={"position": 'inside', "fill": 'white'},
    withLegend=True,
    withTooltip=False,
    series=[
        {"name": "Smartphones", "color": "violet.6"},
        {"name": "Laptops", "color": "blue.6"},
        {"name": "Tablets", "color": "teal.6"},
    ],
    #valueFormatter={"function": "formatNumberIntl"},
)

app.layout = dmc.MantineProvider(
    component2
)

if __name__ == "__main__":
    app.run(debug=True)


```
