### PR TITLE
expose `MantineHooks` and `MantineCore` for use with custom components

### DIFF
--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -3,6 +3,11 @@ import {
     MantineProviderProps,
 } from '@mantine/core';
 import React from 'react';
+import * as MantineCore from '@mantine/core';
+import * as MantineHooks from '@mantine/hooks';
+
+(window as any).MantineCore = MantineCore;
+(window as any).MantineHooks = MantineHooks;
 
 import '@mantine/core/styles.css';
 


### PR DESCRIPTION
To utilize in custom components, you need to place this in your `webpack.config.js` `externals`:

```
         '@mantine/core': {
            commonjs: '@mantine/core',
            commonjs2: '@mantine/core',
            amd: '@mantine/core',
            root: 'MantineCore', // This maps to window.MantineCore
        },
        '@mantine/hooks': {
            commonjs: '@mantine/hooks',
            commonjs2: '@mantine/hooks',
            amd: '@mantine/hooks',
            root: 'MantineHooks', // This maps to window.MantineHooks
        },
```