### PR TITLE
Updated for Mantine 8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - added `DirectionProvider` to handle RTL (right-to-left) text direction.  #650 by @AnnMarieW
 - added `debounce` prop to `Autocomplete #654 by @AnnMarieW
 
+The following new features available in Mantine 8.3.0 were added in #655 by @AnnMarieW
+- `MiniCalendar` component
+- `orientation` prop for `Progress`.  Now supports both horizontal and vertical orientation
+- `clearSearchOnChange` prop for `MultiSelect` - to clear search input when an item is selected
+- `reverseTimeControlsList`  prop for `TimePicker` -  to reverse the order of time controls in the dropdown. Use this option if you want the order of controls to match keyboard controls (up and down arrow) direction.
+
 ### Fixed
 
 - BarChart: Added default `valueFormatter` to prevent rendering issues when `valueFormatter` is undefined. #464 by @AnnMarieW

--- a/src/ts/components/core/combobox/MultiSelect.tsx
+++ b/src/ts/components/core/combobox/MultiSelect.tsx
@@ -50,6 +50,8 @@ interface Props
     hiddenInputValuesDivider?: string;
     /** Props passed down to the underlying `ScrollArea` component in the dropdown */
     scrollAreaProps?: ScrollAreaProps;
+    /** Clear search value when item is selected. Default True */
+    clearSearchOnChange?: boolean;
 }
 
 /** MultiSelect */

--- a/src/ts/components/dates/MiniCalendar.tsx
+++ b/src/ts/components/dates/MiniCalendar.tsx
@@ -1,0 +1,78 @@
+import { MantineSize } from '@mantine/core';
+import { MiniCalendar as MantineMiniCalendar } from '@mantine/dates';
+import { useDidUpdate } from '@mantine/hooks';
+import { BoxProps } from 'props/box';
+import { DashBaseProps, PersistenceProps } from 'props/dash';
+import { StylesApiProps } from 'props/styles';
+import React, { useState } from 'react';
+import { setPersistence } from '../../utils/dash3';
+import { resolveProp, parseFuncProps } from '../../utils/prop-functions';
+
+interface Props
+    extends DashBaseProps,
+        PersistenceProps,
+        BoxProps,
+        StylesApiProps {
+    /** Controlled component date value, start date of the interval */
+    date?: string;
+
+    /** Uncontrolled component default value, start date of the interval */
+    defaultDate?: string;
+
+    /** Selected date, controlled value */
+    value?: string | null;
+
+    /** Maximum date that can be selected, date object or date string in `YYYY-MM-DD` format */
+    maxDate?: string;
+
+    /** Minimum date that can be selected, date object or date string in `YYYY-MM-DD` format */
+    minDate?: string;
+
+    /** Number of days to display in the calendar default 7 */
+    numberOfDays?: number;
+
+    /** Dayjs format string for month label default `MMM` */
+    monthLabelFormat?: string;
+
+    /** A function that passes props down Day component  based on date. (See https://www.dash-mantine-components.com/functions-as-props) */
+    getDayProps?: any;
+
+    /** Component size default 'sm' */
+    size?: MantineSize;
+
+    /** dayjs locale used for formatting */
+    locale?: string;
+}
+
+/** Compact calendar to display a small number of days in a row */
+const MiniCalendar = ({
+    setProps,
+    value,
+    persistence,
+    persisted_props,
+    persistence_type,
+    ...others
+}: Props) => {
+    const [date, setDate] = useState(value);
+
+    useDidUpdate(() => {
+        setDate(value);
+    }, [value]);
+
+    useDidUpdate(() => {
+        setProps({ value: date });
+    }, [date]);
+
+    return (
+        <MantineMiniCalendar
+            onChange={setDate}
+            value={date}
+            //  {...others}
+            {...parseFuncProps('MiniCalendar', others)}
+        />
+    );
+};
+
+setPersistence(MiniCalendar);
+
+export default MiniCalendar;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -154,6 +154,7 @@ import DatePicker from './components/dates/DatePicker';
 import DatePickerInput from './components/dates/DatePickerInput';
 import DateTimePicker from './components/dates/DateTimePicker';
 import DatesProvider from './components/dates/DatesProvider';
+import MiniCalendar from './components/dates/MiniCalendar';
 import MonthPickerInput from './components/dates/MonthPickerInput';
 import YearPickerInput from './components/dates/YearPickerInput';
 import TimeGrid from './components/dates/TimeGrid';
@@ -259,6 +260,7 @@ export {
     ListItem,
     Loader,
     LoadingOverlay,
+    MiniCalendar,
     MantineProvider,
     Mark,
     Menu,

--- a/src/ts/props/dates.ts
+++ b/src/ts/props/dates.ts
@@ -287,6 +287,8 @@ export interface TimePickerProps
      * This overrides any values provided directly in the `presets` prop.
      */
     timeRangePresets?: GetTimeRange;
+    /** If set, the time controls list are reversed, default `false` */
+    reverseTimeControlsList?: boolean;
 }
 
 type DatePickerPreset = {

--- a/src/ts/props/progress.ts
+++ b/src/ts/props/progress.ts
@@ -11,6 +11,8 @@ export interface __ProgressRootProps extends BoxProps {
     autoContrast?: boolean;
     /** Controls sections width transition duration, value is specified in ms, `100` by default */
     transitionDuration?: number;
+    /** Controls orientation default `'horizontal'` */
+    orientation?: 'horizontal' | 'vertical';
 }
 export interface ProgressRootProps extends __ProgressRootProps, StylesApiProps {
     /** Content */

--- a/src/ts/utils/prop-functions.ts
+++ b/src/ts/utils/prop-functions.ts
@@ -23,6 +23,7 @@ const funcPropsMap = {
     MultiSelect: ['renderOption', 'filter'],
     TagsInput: ['renderOption', 'filter'],
     Autocomplete: ['renderOption', 'filter'],
+    MiniCalendar: [ 'getDayProps'],
     DatePicker: [
         'getYearControlProps',
         'getMonthControlProps',


### PR DESCRIPTION
Updates for new features introduced in [Mantine 8.3.0 ](https://mantine.dev/changelog/8-3-0/)

- [x] New MiniCalendar component
- [x] Add `orientation="vertical"` to `Progress`
- [x] Add `clearSearchOnChange` prop to `MultiSelect`
- [x] Add `reverseTimeControlsList` to `TimePicker`
- [x]  `TipTap` 3 support  (separate PR)