### PR TITLE
Use custom prop types for style props

### DIFF
--- a/dash_prop_typing.py
+++ b/dash_prop_typing.py
@@ -1,0 +1,89 @@
+# This file is automatically loaded on build time to generate types.
+# For more info see https://github.com/plotly/dash/pull/3152 and https://github.com/plotly/dash/pull/3220
+
+
+def style_prop(type_info, component_name, prop_name):
+    """All generic style props accept scalar values or a dict for responsive styles."""
+    return "typing.Union[str, NumberType, typing.Dict[str, typing.Any]]"
+
+custom_props = {
+    "*": {
+        # Visibility
+        "hiddenFrom": lambda t, c, p: "typing.Union[str, Literal['xs','sm','md','lg','xl'], typing.Dict[str, typing.Any]]",
+        "visibleFrom": lambda t, c, p: "typing.Union[ str, Literal['xs','sm','md','lg','xl'], typing.Dict[str, typing.Any]]",
+
+
+        # Margin
+        "m": style_prop,
+        "my": style_prop,
+        "mx": style_prop,
+        "mt": style_prop,
+        "mb": style_prop,
+        "ms": style_prop,
+        "me": style_prop,
+        "ml": style_prop,
+        "mr": style_prop,
+
+        # Padding
+        "p": style_prop,
+        "py": style_prop,
+        "px": style_prop,
+        "pt": style_prop,
+        "pb": style_prop,
+        "ps": style_prop,
+        "pe": style_prop,
+        "pl": style_prop,
+        "pr": style_prop,
+
+        # Borders / Backgrounds / Colors
+        "bd": style_prop,
+        "bdrs": style_prop,
+        "bg": lambda t, c, p: "typing.Union[str, Literal['blue','cyan','gray','green','indigo','lime','orange','pink','red','teal','violet','yellow','dark','grape'], typing.Dict[str, typing.Any]]",
+        "c": lambda t, c, p: "typing.Union[str, Literal['blue','cyan','gray','green','indigo','lime','orange','pink','red','teal','violet','yellow','dark','grape'], typing.Dict[str, typing.Any]]",
+        "opacity": style_prop,
+
+        # Typography
+        "ff": lambda t, c, p: "typing.Union[str, Literal['monospace','text','heading'], typing.Dict[str, typing.Any]]",
+        "fz": lambda t, c, p: "typing.Union[str, NumberType, Literal['xs','sm','md','lg','xl','h1','h2','h3','h4','h5','h6'], typing.Dict[str, typing.Any]]",
+        "fw": lambda t, c, p: "typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','bold','normal','bolder','lighter'], NumberType, typing.Dict[str, typing.Any]]",
+        "lts": style_prop,
+        "ta": lambda t, c, p: "typing.Union[str, Literal['left','right','center','justify','start','end','match-parent','-moz-initial','inherit','initial','revert','revert-layer','unset','-webkit-match-parent'], typing.Dict[str, typing.Any]]",
+        "lh": style_prop,
+        "fs": lambda t, c, p: "typing.Union[str, Literal['normal','italic','oblique','-moz-initial','inherit','initial','revert','revert-layer','unset'], typing.Dict[str, typing.Any]]",
+        "tt": lambda t, c, p: "typing.Union[str, Literal['none','capitalize','full-size-kana','full-width','lowercase','uppercase','-moz-initial','inherit','initial','revert','revert-layer','unset'], typing.Dict[str, typing.Any]]",
+        "td": style_prop,
+
+        # Sizing
+        "w": style_prop,
+        "miw": style_prop,
+        "maw": style_prop,
+        "h": style_prop,
+        "mih": style_prop,
+        "mah": style_prop,
+
+        # Background
+        "bgsz": style_prop,
+        "bgp": style_prop,
+        "bgr": lambda t, c, p: "typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','no-repeat','repeat','repeat-x','repeat-y','round','space'], typing.Dict[str, typing.Any]]",
+        "bga": lambda t, c, p: "typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','fixed','local','scroll'], typing.Dict[str, typing.Any]]",
+
+        # Layout
+        "pos": lambda t, c, p: "typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','fixed','-webkit-sticky','absolute','relative','static','sticky'], typing.Dict[str, typing.Any]]",
+        "top": style_prop,
+        "left": style_prop,
+        "bottom": style_prop,
+        "right": style_prop,
+        "inset": style_prop,
+        "display": lambda t, c, p: "typing.Union[str, Literal['flex','-moz-initial','inherit','initial','revert','revert-layer','unset','none','block','inline','run-in','-ms-flexbox','-ms-grid','-webkit-flex','flow','flow-root','grid','ruby','table','ruby-base','ruby-base-container','ruby-text','ruby-text-container','table-caption','table-cell','table-column','table-column-group','table-footer-group','table-header-group','table-row','table-row-group','-ms-inline-flexbox','-ms-inline-grid','-webkit-inline-flex','inline-block','inline-flex','inline-grid','inline-list-item','inline-table','contents','list-item'], typing.Dict[str, typing.Any]]",
+        "flex": style_prop,
+    }
+}
+
+#
+# custom_imports = {
+#     "typing": ["Union"],
+#     "dash.development.base_component": ["NumberType"],
+# }
+
+# types props as any
+#ignore_props = ["style"]


### PR DESCRIPTION
Here is an alternate way to generate the correct Python types for the Mantine Style Props.  This PR could replace  #685 

The solution in pr 685 redefines the types to make them simpler so they can be handled by the dash toolchain. 
This PR keeps the Typescript types from Mantine  and uses the `dash_prop_typing.py` file to provide custom Python types.  

 Advantages 
  - Provides a better typing for the dict for the responsive styles `typing.Dict[str, typing.Any]` rather than just `dict`. 
  -  Keeps the stronger TypeScript types defined in Mantine. 
  -  Keeps the typehints for the Mantine types and literals for example `  fz: typing.Optional[typing.Union[str, NumberType, Literal['xs','sm','md','lg','xl','h1','h2','h3','h4','h5','h6'], typing.Dict[str, typing.Any]]] = None,`

Disadvantages
 - the autogenerated prop docstrings are not correct.  Most of the types are missing, plus it uses the descriptions from Mantine which are not as clear - or are missing.   The prop descriptions in PR 685 are much better for dash users.
 -  The literals included are not complete so may be misleading.  For example, it's valid to have in the `c` prop the color number from the theme as well, for example  `red.6`. 

Here is the result:

`Box.py`
```python
# AUTO GENERATED FILE - DO NOT EDIT

import typing  # noqa: F401
from typing_extensions import TypedDict, NotRequired, Literal # noqa: F401
from dash.development.base_component import Component, _explicitize_args

ComponentType = typing.Union[
    str,
    int,
    float,
    Component,
    None,
    typing.Sequence[typing.Union[str, int, float, Component, None]],
]

NumberType = typing.Union[
    typing.SupportsFloat, typing.SupportsInt, typing.SupportsComplex
]


class Box(Component):
    """A Box component.
Box

Keyword arguments:

- children (a list of or a singular dash component, string or number; optional)

- id (string; optional):
    Unique ID to identify this component in Dash callbacks.

- aria-* (string; optional):
    Wild card aria attributes.

- bd (string | number; optional):
    Border.

- bdrs (number; optional):
    BorderRadius, theme key: theme.radius.

- bg (optional):
    Background, theme key: theme.colors.

- bga (optional):
    BackgroundAttachment.

- bgp (string | number; optional):
    BackgroundPosition.

- bgr (optional):
    BackgroundRepeat.

- bgsz (string | number; optional):
    BackgroundSize.

- bottom (string | number; optional)

- c (optional):
    Color.

- className (string; optional):
    Class added to the root element, if applicable.

- darkHidden (boolean; optional):
    Determines whether component should be hidden in dark color scheme
    with `display: none`.

- data-* (string; optional):
    Wild card data attributes.

- display (optional)

- ff (optional):
    FontFamily.

- flex (string | number; optional)

- fs (optional):
    FontStyle.

- fw (optional):
    FontWeight.

- fz (number; optional):
    FontSize, theme key: theme.fontSizes.

- h (string | number; optional):
    Height, theme key: theme.spacing.

- hiddenFrom (optional):
    Breakpoint above which the component is hidden with `display:
    none`.

- inset (string | number; optional)

- left (string | number; optional)

- lh (number; optional):
    LineHeight, theme key: lineHeights.

- lightHidden (boolean; optional):
    Determines whether component should be hidden in light color
    scheme with `display: none`.

- loading_state (dict; optional):
    Object that holds the loading state object coming from
    dash-renderer. For use with dash<3.

    `loading_state` is a dict with keys:

    - is_loading (boolean; required):
        Determines if the component is loading or not.

    - prop_name (string; required):
        Holds which property is loading.

    - component_name (string; required):
        Holds the name of the component that is loading.

- lts (string | number; optional):
    LetterSpacing.

- m (number; optional):
    Margin, theme key: theme.spacing.

- mah (string | number; optional):
    MaxHeight, theme key: theme.spacing.

- maw (string | number; optional):
    MaxWidth, theme key: theme.spacing.

- mb (number; optional):
    MarginBottom, theme key: theme.spacing.

- me (number; optional):
    MarginInlineEnd, theme key: theme.spacing.

- mih (string | number; optional):
    MinHeight, theme key: theme.spacing.

- miw (string | number; optional):
    MinWidth, theme key: theme.spacing.

- ml (number; optional):
    MarginLeft, theme key: theme.spacing.

- mod (string | dict with strings as keys and values of type boolean | number | string | dict | list; optional):
    Element modifiers transformed into `data-` attributes, for
    example, `{ 'data-size': 'xl' }`, falsy values are removed.

- mr (number; optional):
    MarginRight, theme key: theme.spacing.

- ms (number; optional):
    MarginInlineStart, theme key: theme.spacing.

- mt (number; optional):
    MarginTop, theme key: theme.spacing.

- mx (number; optional):
    MarginInline, theme key: theme.spacing.

- my (number; optional):
    MarginBlock, theme key: theme.spacing.

- opacity (optional)

- p (number; optional):
    Padding, theme key: theme.spacing.

- pb (number; optional):
    PaddingBottom, theme key: theme.spacing.

- pe (number; optional):
    PaddingInlineEnd, theme key: theme.spacing.

- pl (number; optional):
    PaddingLeft, theme key: theme.spacing.

- pos (optional):
    Position.

- pr (number; optional):
    PaddingRight, theme key: theme.spacing.

- ps (number; optional):
    PaddingInlineStart, theme key: theme.spacing.

- pt (number; optional):
    PaddingTop, theme key: theme.spacing.

- px (number; optional):
    PaddingInline, theme key: theme.spacing.

- py (number; optional):
    PaddingBlock, theme key: theme.spacing.

- right (string | number; optional)

- ta (optional):
    TextAlign.

- tabIndex (number; optional):
    tab-index.

- td (string | number; optional):
    TextDecoration.

- top (string | number; optional)

- tt (optional):
    TextTransform.

- visibleFrom (optional):
    Breakpoint below which the component is hidden with `display:
    none`.

- w (string | number; optional):
    Width, theme key: theme.spacing."""
    _children_props: typing.List[str] = []
    _base_nodes = ['children']
    _namespace = 'dash_mantine_components'
    _type = 'Box'
    LoadingState = TypedDict(
        "LoadingState",
            {
            "is_loading": bool,
            "prop_name": str,
            "component_name": str
        }
    )


    def __init__(
        self,
        children: typing.Optional[ComponentType] = None,
        className: typing.Optional[str] = None,
        style: typing.Optional[typing.Any] = None,
        hiddenFrom: typing.Optional[typing.Union[str, Literal['xs','sm','md','lg','xl'], typing.Dict[str, typing.Any]]] = None,
        visibleFrom: typing.Optional[typing.Union[ str, Literal['xs','sm','md','lg','xl'], typing.Dict[str, typing.Any]]] = None,
        lightHidden: typing.Optional[bool] = None,
        darkHidden: typing.Optional[bool] = None,
        mod: typing.Optional[typing.Union[str, typing.Dict[typing.Union[str, float, int], typing.Any]]] = None,
        m: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        my: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mx: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mt: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mb: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        ms: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        me: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        ml: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mr: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        p: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        py: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        px: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        pt: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        pb: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        ps: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        pe: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        pl: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        pr: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bd: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bdrs: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bg: typing.Optional[typing.Union[str, Literal['blue','cyan','gray','green','indigo','lime','orange','pink','red','teal','violet','yellow','dark','grape'], typing.Dict[str, typing.Any]]] = None,
        c: typing.Optional[typing.Union[str, Literal['blue','cyan','gray','green','indigo','lime','orange','pink','red','teal','violet','yellow','dark','grape'], typing.Dict[str, typing.Any]]] = None,
        opacity: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        ff: typing.Optional[typing.Union[str, Literal['monospace','text','heading'], typing.Dict[str, typing.Any]]] = None,
        fz: typing.Optional[typing.Union[str, NumberType, Literal['xs','sm','md','lg','xl','h1','h2','h3','h4','h5','h6'], typing.Dict[str, typing.Any]]] = None,
        fw: typing.Optional[typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','bold','normal','bolder','lighter'], NumberType, typing.Dict[str, typing.Any]]] = None,
        lts: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        ta: typing.Optional[typing.Union[str, Literal['left','right','center','justify','start','end','match-parent','-moz-initial','inherit','initial','revert','revert-layer','unset','-webkit-match-parent'], typing.Dict[str, typing.Any]]] = None,
        lh: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        fs: typing.Optional[typing.Union[str, Literal['normal','italic','oblique','-moz-initial','inherit','initial','revert','revert-layer','unset'], typing.Dict[str, typing.Any]]] = None,
        tt: typing.Optional[typing.Union[str, Literal['none','capitalize','full-size-kana','full-width','lowercase','uppercase','-moz-initial','inherit','initial','revert','revert-layer','unset'], typing.Dict[str, typing.Any]]] = None,
        td: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        w: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        miw: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        maw: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        h: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mih: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        mah: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bgsz: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bgp: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bgr: typing.Optional[typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','no-repeat','repeat','repeat-x','repeat-y','round','space'], typing.Dict[str, typing.Any]]] = None,
        bga: typing.Optional[typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','fixed','local','scroll'], typing.Dict[str, typing.Any]]] = None,
        pos: typing.Optional[typing.Union[str, Literal['-moz-initial','inherit','initial','revert','revert-layer','unset','fixed','-webkit-sticky','absolute','relative','static','sticky'], typing.Dict[str, typing.Any]]] = None,
        top: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        left: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        bottom: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        right: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        inset: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        display: typing.Optional[typing.Union[str, Literal['flex','-moz-initial','inherit','initial','revert','revert-layer','unset','none','block','inline','run-in','-ms-flexbox','-ms-grid','-webkit-flex','flow','flow-root','grid','ruby','table','ruby-base','ruby-base-container','ruby-text','ruby-text-container','table-caption','table-cell','table-column','table-column-group','table-footer-group','table-header-group','table-row','table-row-group','-ms-inline-flexbox','-ms-inline-grid','-webkit-inline-flex','inline-block','inline-flex','inline-grid','inline-list-item','inline-table','contents','list-item'], typing.Dict[str, typing.Any]]] = None,
        flex: typing.Optional[typing.Union[str, NumberType, typing.Dict[str, typing.Any]]] = None,
        id: typing.Optional[typing.Union[str, dict]] = None,
        tabIndex: typing.Optional[NumberType] = None,
        loading_state: typing.Optional["LoadingState"] = None,
        **kwargs
    ):
        self._prop_names = ['children', 'id', 'aria-*', 'bd', 'bdrs', 'bg', 'bga', 'bgp', 'bgr', 'bgsz', 'bottom', 'c', 'className', 'darkHidden', 'data-*', 'display', 'ff', 'flex', 'fs', 'fw', 'fz', 'h', 'hiddenFrom', 'inset', 'left', 'lh', 'lightHidden', 'loading_state', 'lts', 'm', 'mah', 'maw', 'mb', 'me', 'mih', 'miw', 'ml', 'mod', 'mr', 'ms', 'mt', 'mx', 'my', 'opacity', 'p', 'pb', 'pe', 'pl', 'pos', 'pr', 'ps', 'pt', 'px', 'py', 'right', 'style', 'ta', 'tabIndex', 'td', 'top', 'tt', 'visibleFrom', 'w']
        self._valid_wildcard_attributes =            ['data-', 'aria-']
        self.available_properties = ['children', 'id', 'aria-*', 'bd', 'bdrs', 'bg', 'bga', 'bgp', 'bgr', 'bgsz', 'bottom', 'c', 'className', 'darkHidden', 'data-*', 'display', 'ff', 'flex', 'fs', 'fw', 'fz', 'h', 'hiddenFrom', 'inset', 'left', 'lh', 'lightHidden', 'loading_state', 'lts', 'm', 'mah', 'maw', 'mb', 'me', 'mih', 'miw', 'ml', 'mod', 'mr', 'ms', 'mt', 'mx', 'my', 'opacity', 'p', 'pb', 'pe', 'pl', 'pos', 'pr', 'ps', 'pt', 'px', 'py', 'right', 'style', 'ta', 'tabIndex', 'td', 'top', 'tt', 'visibleFrom', 'w']
        self.available_wildcard_properties =            ['data-', 'aria-']
        _explicit_args = kwargs.pop('_explicit_args')
        _locals = locals()
        _locals.update(kwargs)  # For wildcard attrs and excess named props
        args = {k: _locals[k] for k in _explicit_args if k != 'children'}

        super(Box, self).__init__(children=children, **args)

setattr(Box, "__init__", _explicitize_args(Box.__init__))



```