### PR TITLE
remove exposing MantineDates added in pr 653

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Added `TableOfContents` component #513 by @deadkex
 
-- Exposed Mantine Core, Mantine Hooks, and Mantine Dates on the global window object for use in custom Dash 
+- Exposed `MantineCore` and `MantineHooks` on the global window object for use in custom Dash 
 components. This enables building custom Dash components that depend on Mantine components or hooks while remaining
 compatible with Dash Mantine Components. #653 by @BSd3v
 

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -5,11 +5,9 @@ import {
 import React from 'react';
 import * as MantineCore from '@mantine/core';
 import * as MantineHooks from '@mantine/hooks';
-import * as MantineDates from '@mantine/dates';
 
 (window as any).MantineCore = MantineCore;
 (window as any).MantineHooks = MantineHooks;
-(window as any).MantineDates = MantineDates;
 
 import '@mantine/core/styles.css';
 


### PR DESCRIPTION
I added MantineDates to PR #653 because it added functionality without increasing the bundle size.  However it may be necessary to support lazy loading of date components in Mantine 9 which will be released later this year.  

The PR 653 makes certain Mantine modules available on the golobal window object, but it does not support lazy loading.

See issue #641 for more details.

This PR removes exposing `MantineDates` for now.  It is not a breaking change because PR 653 has not been released.