### PR TITLE
add buttonProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Unreleased
+
+### Added
+
+- Added `buttonProps` to `Button`, `ActionIcon`, `UnstyledButton`, `CopyButton` components to allow passing props directly to the underlying button element. #716 by @AnnMarieW
+
 # 2.6.1
 
 ### Fixed

--- a/src/ts/components/core/button/ActionIcon.tsx
+++ b/src/ts/components/core/button/ActionIcon.tsx
@@ -16,6 +16,7 @@ const ActionIcon = ({
     loading_state,
     disabled,
     n_clicks = 0,
+    buttonProps,
     ...others
 }: Props) => {
     const increment = () => {
@@ -28,6 +29,7 @@ const ActionIcon = ({
 
     return (
         <MantineActionIcon
+            {...buttonProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             disabled={disabled}
             onClick={increment}

--- a/src/ts/components/core/button/Button.tsx
+++ b/src/ts/components/core/button/Button.tsx
@@ -41,6 +41,8 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
     autoContrast?: boolean;
     /** An integer that represents the number of times that this element has been clicked on */
     n_clicks?: number;
+    /** Props passed down to the `Button` component **/
+    buttonProps?: object;
 }
 
 /** Button */
@@ -50,6 +52,7 @@ const Button = ({
     loading_state,
     disabled,
     n_clicks = 0,
+    buttonProps,
     ...others
 }: Props) => {
     const increment = () => {
@@ -62,6 +65,7 @@ const Button = ({
 
     return (
         <MantineButton
+            {...buttonProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onClick={increment}
             disabled={disabled}

--- a/src/ts/components/core/button/CopyButton.tsx
+++ b/src/ts/components/core/button/CopyButton.tsx
@@ -47,6 +47,8 @@ interface Props extends DashBaseProps, BoxProps, StylesApiProps {
      *  `value` prop will be copied.
      */
     target_id?: string;
+    /** Props passed down to the `Button` component **/
+    buttonProps?: object;
 }
 /** CopyButton - Button component with copy to clipboard functionality */
 const CopyButton = ({
@@ -61,6 +63,7 @@ const CopyButton = ({
     disabled,
     n_clicks = 0,
     target_id,
+    buttonProps,
     ...others
 }: Props) => {
     const copyFnRef = useRef<(() => void) | null>(null);
@@ -99,6 +102,7 @@ const CopyButton = ({
                 copyFnRef.current = copy;
                 return (
                     <MantineButton
+                        {...buttonProps}
                         onClick={() => handleClick(copy)}
                         disabled={disabled}
                         color={copied ? copiedColor || color : color}

--- a/src/ts/components/core/button/UnstyledButton.tsx
+++ b/src/ts/components/core/button/UnstyledButton.tsx
@@ -15,6 +15,8 @@ export interface Props
     n_clicks?: number;
     /** Indicates disabled state */
     disabled?: boolean;
+    /** Props passed down to the `Button` component **/
+    buttonProps?: object;
 }
 
 /** UnstyledButton */
@@ -24,6 +26,7 @@ const UnstyledButton = ({
     loading_state,
     disabled,
     n_clicks = 0,
+    buttonProps,
     ...others
 }: Props) => {
     const increment = () => {
@@ -36,6 +39,7 @@ const UnstyledButton = ({
 
     return (
         <MantineUnstyledButton
+            {...buttonProps}
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
             onClick={increment}
             disabled={disabled}

--- a/src/ts/props/actionicon.ts
+++ b/src/ts/props/actionicon.ts
@@ -28,4 +28,6 @@ export interface ActionIconProps extends BoxProps, StylesApiProps {
     children?: React.ReactNode;
     /** Determines whether button text color with filled variant should depend on `background-color`. If luminosity of the `color` prop is less than `theme.luminosityThreshold`, then `theme.white` will be used for text color, otherwise `theme.black`. Overrides `theme.autoContrast`. */
     autoContrast?: boolean;
+    /** Props passed down to the `Button` component **/
+    buttonProps?: object;
 }

--- a/src/ts/props/button.ts
+++ b/src/ts/props/button.ts
@@ -12,6 +12,8 @@ export interface __BaseButtonProps {
     children?: React.ReactNode;
     /** Replaces default close icon. If set, `iconSize` prop is ignored. */
     icon?: React.ReactNode;
+    /** props passed down to `Button` component **/
+    ButtonProps?: object;
 }
 
 export interface __CloseButtonProps extends __BaseButtonProps {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,22 @@
+
+from dash import Dash, html, _dash_renderer
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+
+
+def test_001bu_button(dash_duo):
+    app = Dash(__name__)
+
+    component = dmc.Button("Button text", id="button", buttonProps={"type": "submit"})
+
+    app.layout = dmc.MantineProvider(html.Div([component]))
+
+    dash_duo.start_server(app)
+
+    # Wait for the app to load
+    dash_duo.wait_for_text_to_equal("#button", "Button text")
+
+    assert dash_duo.find_element('#button').get_attribute("type") == "submit"
+
+    assert dash_duo.get_logs() == []


### PR DESCRIPTION
closes https://github.com/snehilvj/dash-mantine-components/issues/715

This PR adds `buttonProps` to make it possible to pass any valid attribute to the button element.

For example as requested in issue 715, you can set the button type to submit like this:

```
dmc.Button(buttonProps={"type": "submit"})
```