### PR TITLE
Update active navlink 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Added
 
-- Added  `activeHref` for custom active-state matching independent of navigation, and introduce `exact-with-search` to match both pathname and query parameters. #718 by @AnnMarieW
+- Added  two features to `NavLink` to improve route-based active state without requiring callbacks. #719 by @AnnMarieW
+  - `active="exact-with-search"` matches both pathname and query parameters.
+  - `active="children"` sets parent link to active if any child links are active.
+  
 - Added `buttonProps` to `Button`, `ActionIcon`, `UnstyledButton`, `CopyButton` components to allow passing props directly to the underlying button element. #716 by @AnnMarieW
 
 # 2.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added  `activeHref` for custom active-state matching independent of navigation, and introduce `exact-with-search` to match both pathname and query parameters. #718 by @AnnMarieW
 - Added `buttonProps` to `Button`, `ActionIcon`, `UnstyledButton`, `CopyButton` components to allow passing props directly to the underlying button element. #716 by @AnnMarieW
 
 # 2.6.1

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -26,14 +26,22 @@ interface Props
     rightSection?: React.ReactNode;
     /**
      * Controls whether the link is styled as active (default: `false`).
-     * - `exact`: Active if `pathname` matches `href` exactly.
-     * - `partial`: Active if `pathname` starts with `href` (for subpages).
+     *
+     * - `False`: never active, overrides all matching behavior.
+     * - `True`: always active, overrides all matching behavior.
+     * - `exact`: active when the current `pathname` matches `href` pathname exactly.
+     * - `partial`: active when the current `pathname` starts with `href` pathname.
+     * - `exact-with-search`: active when both `pathname` and query parameters
+     *   match `href`. Query parameters are compared after decoding and are
+     *   order-insensitive.
      */
-    active?: boolean | 'exact' | 'partial';
+    active?: boolean | 'exact' | 'partial' | 'exact-with-search';
     /** Key of `theme.colors` of any valid CSS color to control active styles, `theme.primaryColor` by default */
     color?: MantineColor;
     /** href */
     href?: string;
+    /** Href used only for active state matching. Overrides href for matching and allows non-navigable links to be styled as active. */
+    activeHref?: string,
     /** Target */
     target?: TargetProps;
     /** If set, label and description will not wrap to the next line, `false` by default */
@@ -56,10 +64,13 @@ interface Props
     refresh?: boolean;
 }
 
-/** NavLink */
+/**
+ * Navigation link with nested collapse support. Automatically styles as active based on URL matching.
+ */
 const NavLink = ({
     disabled,
     href,
+    activeHref,
     target,
     refresh,
     n_clicks = 0,
@@ -75,55 +86,88 @@ const NavLink = ({
 }: Props) => {
     const [linkActive, setLinkActive] = useState(false);
 
-    const pathnameToActive = (pathname) => {
-        setLinkActive(
-            active === true ||
-                (active === 'exact' && pathname === href) ||
-                (active === 'partial' &&
-                    (pathname.startsWith(href + '/') || pathname === href))
-        );
+    const normalizePath = (p?: string) =>
+        p && p.endsWith('/') && p !== '/' ? p.slice(0, -1) : p;
+
+    const normalizeSearch = (search: string) => {
+        const params = new URLSearchParams(search);
+        params.sort();
+        return params.toString();
     };
+
+    const matchesRoute = () => {
+        const matchHref = activeHref || href;
+        if (!matchHref || typeof active !== 'string') return false;
+
+        // Safely parse URL
+        let url: URL;
+        try {
+            url = new URL(matchHref, window.location.origin);
+        } catch (e) {
+            return false;
+        }
+
+        const currentPath = normalizePath(window.location.pathname);
+        const targetPath = normalizePath(url.pathname);
+
+        if (active === 'exact') {
+            return currentPath === targetPath;
+        }
+
+        if (active === 'partial') {
+            return (
+                currentPath === targetPath ||
+                currentPath.startsWith(targetPath + '/')
+            );
+        }
+
+        if (active === 'exact-with-search') {
+            return (
+                currentPath === targetPath &&
+                normalizeSearch(window.location.search) === normalizeSearch(url.search)
+            );
+        }
+
+        return false;
+    };
+
+    const updateActiveStyle = () => {
+        setLinkActive(typeof active === 'boolean' ? active : matchesRoute());
+    };
+
 
     useEffect(() => {
-        pathnameToActive(window.location.pathname);
+        updateActiveStyle();
 
         if (typeof active === 'string') {
-            History.onChange(() => {
-                pathnameToActive(window.location.pathname);
-            });
+            const off = History.onChange(updateActiveStyle);
+            return () => off && off();
         }
-    }, [active]);
+    }, [active, href, activeHref]);
 
-    const onChange = (state: boolean) => {
-        setProps({ opened: state });
-    };
+    const handleClick=(ev: MouseEvent<HTMLAnchorElement>) => {
+        if (disabled) return;
 
-    const increment = () => {
-        if (!disabled) {
-            setProps({
-                n_clicks: n_clicks + 1,
-            });
+        setProps({ n_clicks: n_clicks + 1 });
+
+        if (children !== undefined) {
+            setProps({ opened: !opened });
         }
-    };
+
+        if (href) {
+            onClick(ev, href, target, refresh);
+        }
+    }
 
     return (
         <MantineNavLink
             data-dash-is-loading={getLoadingState(loading_state) || undefined}
-            onClick={(ev: MouseEvent<HTMLAnchorElement>) => {
-                increment();
-                if (href) {
-                    onClick(ev, href, target, refresh);
-                }
-                if (children !== undefined) {
-                    setProps({ opened: !opened });
-                }
-            }}
             href={href}
             target={target}
-            onChange={onChange}
             disabled={disabled}
             active={linkActive}
             opened={opened}
+            onClick={handleClick}
             {...others}
         >
             {children}

--- a/src/ts/components/core/NavLink.tsx
+++ b/src/ts/components/core/NavLink.tsx
@@ -86,13 +86,16 @@ const NavLink = ({
 }: Props) => {
     const [linkActive, setLinkActive] = useState(false);
 
-    const normalizePath = (p?: string) =>
-        p && p.endsWith('/') && p !== '/' ? p.slice(0, -1) : p;
+    const normalizePath = (p?: string) => {
+        if (!p) return p;
+        const decoded = decodeURIComponent(p);
+        return decoded.endsWith('/') && decoded !== '/' ? decoded.slice(0, -1) : decoded;
+    };
 
     const normalizeSearch = (search: string) => {
         const params = new URLSearchParams(search);
         params.sort();
-        return params.toString();
+        return decodeURIComponent(params.toString());
     };
 
     const matchesRoute = () => {

--- a/src/ts/components/core/navlink/NavLink.tsx
+++ b/src/ts/components/core/navlink/NavLink.tsx
@@ -64,6 +64,32 @@ interface Props
     refresh?: boolean;
 }
 
+function memoizeOneArg(fn) {
+  const cache = {}; // The "notebook" where results are saved
+  return function(arg) {
+    if (arg in cache) {
+      return cache[arg];
+    }
+    const result = fn(arg); // Compute the result
+    cache[arg] = result; // Store it for future use
+    return result;
+  };
+}
+
+
+
+const normalizePath = memoizeOneArg((p?: string) => {
+    if (!p) return p;
+    const decoded = decodeURIComponent(p);
+    return decoded.endsWith('/') && decoded !== '/' ? decoded.slice(0, -1) : decoded;
+});
+
+const normalizeSearch = memoizeOneArg((search: string) => {
+    const params = new URLSearchParams(search);
+    params.sort();
+    return decodeURIComponent(params.toString());
+});
+
 /**
  * Navigation link with nested collapse support. Automatically styles as active based on URL matching.
  */
@@ -94,18 +120,6 @@ const NavLink = ({
 
     // Parent context
     const parentContext = useContext(NavLinkContext);
-
-    const normalizePath = (p?: string) => {
-        if (!p) return p;
-        const decoded = decodeURIComponent(p);
-        return decoded.endsWith('/') && decoded !== '/' ? decoded.slice(0, -1) : decoded;
-    };
-
-    const normalizeSearch = (search: string) => {
-        const params = new URLSearchParams(search);
-        params.sort();
-        return decodeURIComponent(params.toString());
-    };
 
     const matchesRoute = () => {
 
@@ -142,7 +156,7 @@ const NavLink = ({
         return false;
     };
 
-    const anyChildActive = Object.values(childStates).some(Boolean);
+    const anyChildActive = (active === 'children') && Object.values(childStates).some(Boolean);
 
     const updateActiveStyle = () => {
         if (active === 'children') {

--- a/src/ts/components/core/navlink/NavLink.tsx
+++ b/src/ts/components/core/navlink/NavLink.tsx
@@ -6,10 +6,11 @@ import {
 import { BoxProps } from 'props/box';
 import { DashBaseProps, PersistenceProps } from 'props/dash';
 import { StylesApiProps } from 'props/styles';
-import React, { MouseEvent, useState, useEffect } from 'react';
-import { TargetProps, onClick } from '../../utils/anchor';
+import React, { MouseEvent, useState, useEffect, useContext, useRef } from 'react';
+import { TargetProps, onClick } from '../../../utils/anchor';
 import { History } from '@plotly/dash-component-plugins';
-import { setPersistence, getLoadingState } from '../../utils/dash3';
+import { setPersistence, getLoadingState } from '../../../utils/dash3';
+import NavLinkContext from './NavLinkContext';
 
 interface Props
     extends BoxProps,
@@ -34,14 +35,13 @@ interface Props
      * - `exact-with-search`: active when both `pathname` and query parameters
      *   match `href`. Query parameters are compared after decoding and are
      *   order-insensitive.
+     *   - `children`: active if any nested NavLink is active.
      */
-    active?: boolean | 'exact' | 'partial' | 'exact-with-search';
+    active?: boolean | 'exact' | 'partial' | 'exact-with-search' | 'children';
     /** Key of `theme.colors` of any valid CSS color to control active styles, `theme.primaryColor` by default */
     color?: MantineColor;
     /** href */
     href?: string;
-    /** Href used only for active state matching. Overrides href for matching and allows non-navigable links to be styled as active. */
-    activeHref?: string,
     /** Target */
     target?: TargetProps;
     /** If set, label and description will not wrap to the next line, `false` by default */
@@ -70,7 +70,6 @@ interface Props
 const NavLink = ({
     disabled,
     href,
-    activeHref,
     target,
     refresh,
     n_clicks = 0,
@@ -86,6 +85,16 @@ const NavLink = ({
 }: Props) => {
     const [linkActive, setLinkActive] = useState(false);
 
+    // Track child active states by id
+    const [childStates, setChildStates] = useState<Record<string, boolean>>({});
+
+    // Stable id for this instance
+    const idRef = useRef<string>(Math.random().toString(36).slice(2));
+    const internalId = others.id || idRef.current;
+
+    // Parent context
+    const parentContext = useContext(NavLinkContext);
+
     const normalizePath = (p?: string) => {
         if (!p) return p;
         const decoded = decodeURIComponent(p);
@@ -99,14 +108,13 @@ const NavLink = ({
     };
 
     const matchesRoute = () => {
-        const matchHref = activeHref || href;
-        if (!matchHref || typeof active !== 'string') return false;
 
-        // Safely parse URL
+        if (!href || typeof active !== 'string') return false;
+
         let url: URL;
         try {
-            url = new URL(matchHref, window.location.origin);
-        } catch (e) {
+            url = new URL(href, window.location.origin);
+        } catch {
             return false;
         }
 
@@ -134,10 +142,17 @@ const NavLink = ({
         return false;
     };
 
-    const updateActiveStyle = () => {
-        setLinkActive(typeof active === 'boolean' ? active : matchesRoute());
-    };
+    const anyChildActive = Object.values(childStates).some(Boolean);
 
+    const updateActiveStyle = () => {
+        if (active === 'children') {
+            setLinkActive(anyChildActive);
+        } else {
+            setLinkActive(
+                typeof active === 'boolean' ? active : matchesRoute()
+            );
+        }
+    };
 
     useEffect(() => {
         updateActiveStyle();
@@ -146,9 +161,38 @@ const NavLink = ({
             const off = History.onChange(updateActiveStyle);
             return () => off && off();
         }
-    }, [active, href, activeHref]);
+    }, [active, href,  anyChildActive]);
 
-    const handleClick=(ev: MouseEvent<HTMLAnchorElement>) => {
+    // Stable handler for children reporting active state
+    const onChildActive = React.useCallback(
+        (id: string, isActive: boolean) => {
+            setChildStates((prev) => {
+                if (prev[id] === isActive) return prev; // prevent churn
+                return { ...prev, [id]: isActive };
+            });
+        },
+        []
+    );
+
+    // Stable context value
+    const contextValue = React.useMemo(
+        () => ({ onChildActive }),
+        [onChildActive]
+    );
+
+    // Report this node's active state to parent
+    useEffect(() => {
+        parentContext?.onChildActive?.(internalId, linkActive);
+    }, [linkActive, parentContext]);
+
+    // Cleanup on unmount
+    useEffect(() => {
+        return () => {
+            parentContext?.onChildActive?.(internalId, false);
+        };
+    }, [parentContext]);
+
+    const handleClick = (ev: MouseEvent<HTMLAnchorElement>) => {
         if (disabled) return;
 
         setProps({ n_clicks: n_clicks + 1 });
@@ -160,21 +204,25 @@ const NavLink = ({
         if (href) {
             onClick(ev, href, target, refresh);
         }
-    }
+    };
 
     return (
-        <MantineNavLink
-            data-dash-is-loading={getLoadingState(loading_state) || undefined}
-            href={href}
-            target={target}
-            disabled={disabled}
-            active={linkActive}
-            opened={opened}
-            onClick={handleClick}
-            {...others}
-        >
-            {children}
-        </MantineNavLink>
+        <NavLinkContext.Provider value={contextValue}>
+            <MantineNavLink
+                data-dash-is-loading={
+                    getLoadingState(loading_state) || undefined
+                }
+                href={href}
+                target={target}
+                disabled={disabled}
+                active={linkActive}
+                opened={opened}
+                onClick={handleClick}
+                {...others}
+            >
+                {children}
+            </MantineNavLink>
+        </NavLinkContext.Provider>
     );
 };
 

--- a/src/ts/components/core/navlink/NavLinkContext.tsx
+++ b/src/ts/components/core/navlink/NavLinkContext.tsx
@@ -1,0 +1,9 @@
+import React, {  createContext } from 'react';
+
+// This context allows children to report their active status to parents
+
+const NavLinkContext = createContext<{
+    onChildActive?: (id: string, isActive: boolean) => void;
+} | null>(null);
+
+export default NavLinkContext;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -39,7 +39,7 @@ import Mark from './components/core/Mark';
 import Modal from './components/core/modal/Modal';
 import ModalStack from './components/core/modal/ModalStack';
 import ManagedModal from './components/core/modal/ManagedModal';
-import NavLink from './components/core/NavLink';
+import NavLink from './components/core/navlink/NavLink';
 import NumberFormatter from './components/core/NumberFormatter';
 import Overlay from './components/core/Overlay';
 import Pagination from './components/core/Pagination';

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -169,6 +169,7 @@ def navlink_query_app():
 
     dash.register_page("reports", path="/reports", layout=reports_layout)
     dash.register_page("settings", path="/settings", layout=html.Div("Settings"))
+    dash.register_page("path_template_page", path_template="/reports/<type>", layout=reports_layout)
 
     component = dmc.Box([
         dmc.NavLink(label="Home", id="home", href="/", active="exact"),
@@ -192,6 +193,12 @@ def navlink_query_app():
                     id="inventory",
                     href="/reports?type=Inventory",
                     active="exact-with-search",
+                ),
+                dmc.NavLink(
+                    label="Products",
+                    href="/reports/product A",
+                    active="exact",
+                    id="products"
                 ),
             ],
         ),
@@ -240,6 +247,14 @@ def test_navlink_activehref_and_search(dash_duo):
     assert is_active(dash_duo, "reports")
     assert not is_active(dash_duo, "sales")
     assert is_active(dash_duo, "inventory")
+
+    # Click Producs - match path variables
+    dash_duo.find_element("#products").click()
+
+    assert is_active(dash_duo, "reports")
+    assert not is_active(dash_duo, "sales")
+    assert not is_active(dash_duo, "inventory")
+    assert is_active(dash_duo, "products")
 
     # Click Settings (exact)
     dash_duo.find_element("#settings").click()

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -159,3 +159,94 @@ def test_006_navlink(dash_duo):
 
 
 
+def navlink_query_app():
+    app = Dash(__name__, use_pages=True, pages_folder="")
+
+    dash.register_page("home", path="/", layout=html.Div("Home"))
+
+    def reports_layout(type=None, **kwargs):
+        return html.Div(f"{type} Report")
+
+    dash.register_page("reports", path="/reports", layout=reports_layout)
+    dash.register_page("settings", path="/settings", layout=html.Div("Settings"))
+
+    component = dmc.Box([
+        dmc.NavLink(label="Home", id="home", href="/", active="exact"),
+
+        dmc.NavLink(
+            label="Reports",
+            id="reports",
+            active="partial",
+            activeHref="/reports",
+            childrenOffset=28,
+            persistence=True,
+            children=[
+                dmc.NavLink(
+                    label="Sales",
+                    id="sales",
+                    href="/reports?type=Sales",
+                    active="exact-with-search",
+                ),
+                dmc.NavLink(
+                    label="Inventory",
+                    id="inventory",
+                    href="/reports?type=Inventory",
+                    active="exact-with-search",
+                ),
+            ],
+        ),
+
+        dmc.NavLink(label="Settings", id="settings", href="/settings", active="exact"),
+
+        dmc.Divider(mb="lg"),
+        dash.page_container
+    ])
+
+    app.layout = dmc.MantineProvider([component])
+    return app
+
+
+def is_active(dash_duo, id_):
+    el = dash_duo.find_element(f"#{id_}")
+    return el.get_attribute("data-active") == "true"
+
+
+def test_navlink_activehref_and_search(dash_duo):
+    app = navlink_query_app()
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_element("#home")
+
+    # Initial state: home active
+    assert is_active(dash_duo, "home")
+    assert not is_active(dash_duo, "reports")
+
+    # Toggles open/closed child links - no nav
+    dash_duo.find_element("#reports").click()
+    # Click Sales (exact-with-search)
+    dash_duo.find_element("#sales").click()
+
+    dash_duo.wait_for_text_to_equal("#_pages_content", "Sales Report")
+
+    assert is_active(dash_duo, "reports")      # via activeHref + partial
+    assert is_active(dash_duo, "sales")
+    assert not is_active(dash_duo, "inventory")
+    assert not is_active(dash_duo, "home")
+
+    # Click Inventory
+    dash_duo.find_element("#inventory").click()
+    dash_duo.wait_for_text_to_equal("#_pages_content", "Inventory Report")
+
+    assert is_active(dash_duo, "reports")
+    assert not is_active(dash_duo, "sales")
+    assert is_active(dash_duo, "inventory")
+
+    # Click Settings (exact)
+    dash_duo.find_element("#settings").click()
+    dash_duo.wait_for_text_to_equal("#_pages_content", "Settings")
+
+    assert is_active(dash_duo, "settings")
+    assert not is_active(dash_duo, "reports")
+
+    assert dash_duo.get_logs() == []
+

--- a/tests/test_navlink.py
+++ b/tests/test_navlink.py
@@ -177,8 +177,7 @@ def navlink_query_app():
         dmc.NavLink(
             label="Reports",
             id="reports",
-            active="partial",
-            activeHref="/reports",
+            active="children",
             childrenOffset=28,
             persistence=True,
             children=[


### PR DESCRIPTION

Adds two features to `dmc.NavLink` to improve route-based active state without requiring callbacks.


1.  `active="children"`
closes #717

* Sets parent link to active if any child link is active

Example:

```python
dmc.NavLink(
    label="Reports",
    active="children",  
    children=[...],
)
```

2. `active="exact-with-search"`
closes #678

* Marks a link as active only when both the pathname and query string match.
* Query parameters are compared after decoding and are order-insensitive.

Example:

```python
dmc.NavLink(
    label="Sales",
    href="/reports?type=Sales",
    active="exact-with-search",
)
```

**Additional notes**

* `active=True` and `active=False` still override all matching behavior.
* Existing `exact` and `partial` modes are fixed so they ignore query parameters for match
* Click behavior for links with `children` is updated so they can act as non-navigable toggles when `href` is not provided.



Here is a complete minimal example:

```python

import dash
import dash_mantine_components as dmc
from dash import Dash, html

app = Dash(use_pages=True, pages_folder="")


dash.register_page("home", path="/", layout=html.Div("Home"))

def reports_layout(type=None, **kwargs):
    return html.Div(f"{type} Report ")

dash.register_page("reports", path="/reports", layout=reports_layout)
dash.register_page("settings", path="/settings", layout=html.Div("Settings"))


component = dmc.Box([
    dmc.NavLink(label="Home", href="/", active="exact"),

    dmc.NavLink(
        label="Reports",
        # non-navigable parent
        active="childrenl",       
        childrenOffset=28,
        persistence=True,
        children=[
            dmc.NavLink(
                label="Sales",
                href="/reports?type=Sales",
                active="exact-with-search",
            ),
            dmc.NavLink(
                label="Inventory",
                href="/reports?type=Inventory",
                active="exact-with-search",
            ),
        ],
    ),

    dmc.NavLink(label="Settings", href="/settings", active="exact"),

    dmc.Divider(mb="lg"),
    dash.page_container
])

app.layout = dmc.MantineProvider([component])

if __name__ == "__main__":
    app.run(debug=True)



```

<img width="994" height="666" alt="image" src="https://github.com/user-attachments/assets/6e097fb2-f5e3-4c5f-9b0f-318d1096d637" />





