### PR TITLE
Add 'valueLabelProp' to BarChart properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Unreleased
+
+### Added
+
+- Enable functions in valueLabelProps in BarChart  #724 by @almostBurtMacklin 
+
 # 2.7.0
 
 ### Added

--- a/src/ts/utils/prop-functions.ts
+++ b/src/ts/utils/prop-functions.ts
@@ -64,7 +64,7 @@ const funcPropsMap = {
         'gridProps',
         'rightYAxisProps',
         'tooltipProps',
-        'valueLabelProp',  
+        'valueLabelProps',  
         'getBarColor',
     ],
     BubbleChart: [

--- a/src/ts/utils/prop-functions.ts
+++ b/src/ts/utils/prop-functions.ts
@@ -64,6 +64,7 @@ const funcPropsMap = {
         'gridProps',
         'rightYAxisProps',
         'tooltipProps',
+        'valueLabelProp',  
         'getBarColor',
     ],
     BubbleChart: [


### PR DESCRIPTION
Allows for custom component for the label prop - fix for issue: #723 