### PR TITLE
add getStyleNonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Added
 
 - Added Heatmap component #725 by @AnnMarieW
-- Enable functions in valueLabelProps in BarChart  #724 by @almostBurtMacklin 
+- Enable functions in `valueLabelProps` in `BarChart`  #724 by @almostBurtMacklin 
 
 - Updated RadarChart: #726 by @AnnMarieW
   - allow for functions in props passed to Recharts.
   - added props: `withTooltip`, `tooltipProps`, `tooltipAnimationDuration`, `withDots`, `dotProps`, `activeDotProps`
+
+- Added `getStyleNonce` prop to `MantineProvider`  #731 by @AnnMarieW
 
 # 2.7.0
 

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -23,7 +23,7 @@ interface Props extends MantineProviderProps {
     /** Unique ID to identify this component in Dash callbacks. */
     id?: string;
     /**getStyleNonce is a function to generate [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) attribute added to dynamic generated `<style />` tags.*/
-    getStyleNonce: any;
+    getStyleNonce?: any;
 }
 
 /* MantineProvider */

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -5,6 +5,7 @@ import {
 import React from 'react';
 import * as MantineCore from '@mantine/core';
 import * as MantineHooks from '@mantine/hooks';
+import { parseFuncProps } from '../../utils/prop-functions';
 
 (window as any).MantineCore = MantineCore;
 (window as any).MantineHooks = MantineHooks;
@@ -21,6 +22,8 @@ import '@mantine/notifications/styles.css';
 interface Props extends MantineProviderProps {
     /** Unique ID to identify this component in Dash callbacks. */
     id?: string;
+    /**getStyleNonce is a function to generate nonce attribute added to dynamic generated `<style />` tags.*/
+    getStyleNonce: any;
 }
 
 /* MantineProvider */
@@ -28,7 +31,7 @@ const MantineProvider = (props: Props) => {
     const { children, ...others } = props;
 
     return (
-        <MantineMantineProvider {...others}>{children}</MantineMantineProvider>
+        <MantineMantineProvider {...parseFuncProps('MantineProvider', others)}>{children}</MantineMantineProvider>
     );
 };
 

--- a/src/ts/components/styles/MantineProvider.tsx
+++ b/src/ts/components/styles/MantineProvider.tsx
@@ -22,17 +22,19 @@ import '@mantine/notifications/styles.css';
 interface Props extends MantineProviderProps {
     /** Unique ID to identify this component in Dash callbacks. */
     id?: string;
-    /**getStyleNonce is a function to generate nonce attribute added to dynamic generated `<style />` tags.*/
+    /**getStyleNonce is a function to generate [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) attribute added to dynamic generated `<style />` tags.*/
     getStyleNonce: any;
 }
 
 /* MantineProvider */
 const MantineProvider = (props: Props) => {
-    const { children, ...others } = props;
+  const { children, ...others } = props;
 
-    return (
-        <MantineMantineProvider {...parseFuncProps('MantineProvider', others)}>{children}</MantineMantineProvider>
-    );
+  return (
+    <MantineMantineProvider {...parseFuncProps('MantineProvider', others)}>
+      {children}
+    </MantineMantineProvider>
+  );
 };
 
 export default MantineProvider;

--- a/src/ts/utils/prop-functions.ts
+++ b/src/ts/utils/prop-functions.ts
@@ -17,6 +17,7 @@ import { path } from 'ramda';
  */
 
 const funcPropsMap = {
+    MantineProvider: ['getStyleNonce'],
     Slider: ['label', 'scale'],
     RangeSlider: ['label', 'scale'],
     Select: ['renderOption', 'filter'],


### PR DESCRIPTION
Closes #728

This PR adds `getStylNonce` to the `MantineProvider` component.

Note this only applies the nonce attribute to dynamically generated styles, and not the base styles that are loaded in the header by dash when the app starts.

 `getStyleNonce` is a function to generate a [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) attribute added to dynamically generated `<style />` tags




Here is a sample app:

```python
import dash_mantine_components as dmc
from dash import Dash

app = Dash( meta_tags=[
        {"name": "csp-nonce", "content": "test-nonce-123"}
    ])


component =dmc.Box([
    dmc.Alert(
       "Welcome to Dash Mantine Components",
       title="Hello!",
       color="violet",
    ),
    
])

app.layout = dmc.MantineProvider(
    component,
    getStyleNonce={"function": "getStyleNonce"}
)


if __name__ == "__main__":
    app.run(debug=True)

```

Then in a .js file, you can add something like:

```js

var dmcfuncs = window.dashMantineFunctions = window.dashMantineFunctions || {};


dmcfuncs.getStyleNonce = function() {
    var meta = document.querySelector('meta[name="csp-nonce"]');
    return meta ? meta.getAttribute('content') : null;
};

```


This  only adds the `nonce` attribute in the `style` tags that Mantine injects at runtime.  Any other style tags including the base Mantine styles that are added in the header by dash do not have this attribute.    Also, this only affects DMC and not any other library that may inject style tags.    


--------------------------------
------------------------------

<img width="1898" height="422" alt="Image" src="https://github.com/user-attachments/assets/8acbc077-22b4-4ae1-9345-bfb83739d4e6" />



------------------


The `nonce` attribute is not added to any of  these style tags in the header:


----------------------------------

<img width="1578" height="980" alt="Image" src="https://github.com/user-attachments/assets/fab0bdb7-f668-41fa-b5b5-f280bf64789d" />


