### PR TITLE
fix: prevent dcc.Markdown styles from overriding CodeHighlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Added `getStyleNonce` prop to `MantineProvider`  #731 by @AnnMarieW
 
+### Fixed
+
+- Fixed a CSS specificity issue where Highlight.js styles associated with `dcc.Markdown` could override the dark theme styling of `dmc.CodeHighlight`. #732 by @AnnMarieW
+
 # 2.7.0
 
 ### Added

--- a/src/ts/components/extensions/codehighlight/fragments/dmc-code.css
+++ b/src/ts/components/extensions/codehighlight/fragments/dmc-code.css
@@ -1,4 +1,4 @@
-:where([data-mantine-color-scheme='light']) .dmc-code {
+[data-mantine-color-scheme='light'] .dmc-code .hljs {
     --code-text-color: var(--mantine-color-gray-7);
     --code-background: var(--mantine-color-gray-0);
     --code-comment-color: var(--mantine-color-gray-6);
@@ -10,7 +10,7 @@
     --code-class-color: var(--mantine-color-orange-9);
 }
 
-:where([data-mantine-color-scheme='dark']) .dmc-code {
+[data-mantine-color-scheme='dark'] .dmc-code .hljs {
     --code-text-color: var(--mantine-color-dark-1);
     --code-background: var(--mantine-color-dark-8);
     --code-comment-color: var(--mantine-color-dark-3);
@@ -22,12 +22,12 @@
     --code-class-color: var(--mantine-color-orange-5);
 }
 
-:where([data-mantine-color-scheme='dark']) .hljs {
+[data-mantine-color-scheme='dark'] .dmc-code .hljs {
     color: var(--mantine-color-dark-1);
     background: var(--mantine-color-dark-8);
 }
 
-:where([data-mantine-color-scheme='light']) .hljs {
+[data-mantine-color-scheme='light'] .dmc-code .hljs {
     color: var(--mantine-color-gray-7);
     background: var(--mantine-color-gray-0);
 }


### PR DESCRIPTION
Fixed a CSS specificity issue where Highlight.js styles associated with `dcc.Markdown` could override the dark theme styling of `dmc.CodeHighlight`.