### PR TITLE
Update for React 19

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,9 +4,61 @@ const WebpackDashDynamicImport = require("@plotly/webpack-dash-dynamic-import");
 
 const dashLibraryName = packagejson.name.replace(/-/g, "_");
 
+// Externalized react/jsx-runtime.
+// Newer Dash versions provide window.ReactJSXRuntime for React 19 compatability.
+// The fallback keeps this bundle compatible with older Dash versions.
+const jsxRuntimeExternal = `var (window.ReactJSXRuntime || (window.ReactJSXRuntime = (function (React) {
+    function jsx(type, config, maybeKey) {
+        var props = {};
+        var children = null;
+
+        if (config != null) {
+            if (config.key !== undefined) {
+                props.key = '' + config.key;
+            }
+
+            for (var propName in config) {
+                if (
+                    Object.prototype.hasOwnProperty.call(config, propName) &&
+                    propName !== 'key' &&
+                    propName !== '__self' &&
+                    propName !== '__source'
+                ) {
+                    if (propName === 'children') {
+                        children = config[propName];
+                    } else {
+                        props[propName] = config[propName];
+                    }
+                }
+            }
+        }
+
+        if (maybeKey !== undefined) {
+            props.key = '' + maybeKey;
+        }
+
+        if (children === null || children === undefined) {
+            return React.createElement(type, props);
+        }
+
+        return Array.isArray(children)
+            ? React.createElement.apply(React, [type, props].concat(children))
+            : React.createElement(type, props, children);
+    }
+
+    return {
+        jsx: jsx,
+        jsxs: jsx,
+        jsxDEV: jsx,
+        Fragment: React.Fragment
+    };
+})(window.React)))`;
+
 module.exports = function (env, argv) {
     const mode = (argv && argv.mode) || "production";
+
     const entry = [path.join(__dirname, "src/ts/index.ts")];
+
     const output = {
         path: path.join(__dirname, dashLibraryName),
         chunkFilename: "[name].js",
@@ -30,17 +82,21 @@ module.exports = function (env, argv) {
             umd: "react-dom",
             root: "ReactDOM",
         },
+        "react/jsx-runtime": jsxRuntimeExternal,
+        "react/jsx-dev-runtime": jsxRuntimeExternal,
     };
 
     return {
         output,
         mode,
         entry,
-        target: "web",
+        target: ["web", "es5"],
         externals,
+
         resolve: {
             extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
         },
+
         module: {
             rules: [
                 {
@@ -91,6 +147,7 @@ module.exports = function (env, argv) {
                 },
             ],
         },
+
         optimization: {
             splitChunks: {
                 name: "[name].js",
@@ -118,6 +175,7 @@ module.exports = function (env, argv) {
                 },
             },
         },
+
         plugins: [new WebpackDashDynamicImport()],
     };
 };


### PR DESCRIPTION
This is the start of the update to support React 19 in DMC

DO NOT merge until PR https://github.com/plotly/dash/pull/3880 is available in Dash: 

To do:
- [x] Update webpack to handle external jsx runtime
- [x] Build with the new webpack and run the dmc-docs app with React 19 using this branch and dash branch with PR 3880 (Result: work without any issues/errors)
- [ ] Update tests to use environment variable for react, rather than specifying in the app.
- [ ] Before release, be sure to build with the dash release containing PR 3880
- [ ] Release as a DMC v2 so React 19 can be run with DMC V2 (Mantine V8)
- [ ] Work on DMC v3 (Mantine v9) which requires React 19 in a separate PR.
